### PR TITLE
refactor(config): move two config options from software_params to workflow_params

### DIFF
--- a/src/cgr_gwas_qc/models/config/software_params.py
+++ b/src/cgr_gwas_qc/models/config/software_params.py
@@ -26,11 +26,6 @@ class SoftwareParams(BaseModel):
         0.1, description="Autosomal heterozygosity threshold.", gt=0, le=1
     )
 
-    minimum_pop_subjects: int = Field(
-        50, description="Minimum number of subjects in a population", gt=0
-    )
-    control_hwp_threshold: int = Field(50, description="Control samples HWP threshold.", gt=0)
-
     strand: str = Field(
         "top",
         description="Which strand to use when converting GTC to plink {TOP, FWD, PLUS}. default TOP",

--- a/src/cgr_gwas_qc/models/config/workflow_params.py
+++ b/src/cgr_gwas_qc/models/config/workflow_params.py
@@ -27,6 +27,11 @@ class WorkflowParams(BaseModel):
         True, description="Remove samples that are unexpected replicates."
     )
 
+    minimum_pop_subjects: int = Field(
+        50, description="Minimum number of subjects in a population", gt=0
+    )
+    control_hwp_threshold: int = Field(50, description="Control samples HWP threshold.", gt=0)
+
     @validator("subject_id_to_use")
     def validate_subject_id_to_use(cls, v):
         if v is None:

--- a/src/cgr_gwas_qc/workflow/modules/population_level_summary.smk
+++ b/src/cgr_gwas_qc/workflow/modules/population_level_summary.smk
@@ -63,14 +63,14 @@ rule plink_split_population:
 def required_population_results(wildcards):
     """Decide what populations to analyze.
 
-    If a population has fewer than `software_params.minimum_pop_subjects`
+    If a population has fewer than `workflow_params.minimum_pop_subjects`
     subjects than ignore.
     """
     qc_table = checkpoints.sample_qc_report.get(**wildcards).output[0]
 
     maf = cfg.config.software_params.maf_for_ibd
     ld = cfg.config.software_params.ld_prune_r2
-    population_threshold = cfg.config.software_params.minimum_pop_subjects
+    population_threshold = cfg.config.workflow_params.minimum_pop_subjects
 
     pops = (
         pd.read_csv(qc_table)
@@ -170,13 +170,13 @@ rule plink_split_controls:
 def required_population_controls(wildcards):
     """Decide what populations controls to analyze.
 
-    If population controls have fewer than `software_params.control_hwp_threshold`
+    If population controls have fewer than `workflow_params.control_hwp_threshold`
     subjects than ignore.
     """
     qc_table = checkpoints.sample_qc_report.get(**wildcards).output[0]
 
     maf = 0.05  # TODO: Hardcoded to match legacy
-    control_threshold = cfg.config.software_params.control_hwp_threshold
+    control_threshold = cfg.config.workflow_params.control_hwp_threshold
     pops = (
         pd.read_csv(qc_table)
         .query("Subject_Representative & `Case/Control_Status` == 0")

--- a/tests/models/test_config_data_model.py
+++ b/tests/models/test_config_data_model.py
@@ -139,8 +139,6 @@ def test_software_params_defaults():
     assert software_params.contam_population == "AF"
     assert software_params.pi_hat_threshold == 0.2
     assert software_params.autosomal_het_threshold == 0.1
-    assert software_params.minimum_pop_subjects == 50
-    assert software_params.control_hwp_threshold == 50
     assert software_params.strand == "top"
 
 
@@ -154,6 +152,8 @@ def test_workflow_params_defaults():
     assert workflow_params.remove_sex_discordant is True
     assert workflow_params.remove_rep_discordant is True
     assert workflow_params.remove_unexpected_rep is True
+    assert workflow_params.minimum_pop_subjects == 50
+    assert workflow_params.control_hwp_threshold == 50
 
 
 def test_basic_config():


### PR DESCRIPTION
Moves the `minimum_pop_subjects` and `control_hwp_threshold` to workflow params because they are only used as flow control.

Closes #11