### PR TITLE
feat(parsers): add vcf parser API

### DIFF
--- a/src/cgr_gwas_qc/parsers/vcf.py
+++ b/src/cgr_gwas_qc/parsers/vcf.py
@@ -1,0 +1,42 @@
+from typing import Union
+
+import pysam
+
+
+class VariantFile(pysam.VariantFile):
+    def fetch(
+        self,
+        contig=None,
+        start=None,
+        stop=None,
+        region=None,
+        reopen=False,
+        end=None,
+        reference=None,
+    ):
+        # Ensure correct types if present
+        contig = str(contig) if contig else None
+        start = int(start) if start else None
+        stop = int(stop) if stop else None
+
+        try:
+            return super().fetch(contig, start, stop, region, reopen, end, reference)
+        except ValueError:
+            # Mostlikely this is due to a mismatch in chromosome code between
+            # `contig` and the VCF. Adjust contig to match VCF.
+            contig = self._fix_contig(contig)
+            return super().fetch(contig, start, stop, region, reopen, end, reference)
+
+    def contains_contig(self, contig: Union[int, str]):
+        contig = str(contig)
+        vcf_contigs = self.header.contigs.keys()
+        return contig in vcf_contigs or self._fix_contig(contig) in vcf_contigs
+
+    @staticmethod
+    def _fix_contig(contig: str):
+        if contig.startswith("chr"):
+            # assume the VCF does not start with "chr"
+            return contig.replace("chr", "")
+
+        # assume the VCF does start with "chr"
+        return "chr" + contig

--- a/tests/parsers/test_vcf.py
+++ b/tests/parsers/test_vcf.py
@@ -1,0 +1,47 @@
+import warnings
+
+import pytest
+
+from cgr_gwas_qc.parsers.vcf import VariantFile
+from cgr_gwas_qc.testing.data import RealData
+
+
+@pytest.mark.real_data
+@pytest.fixture(scope="session", params=[37, 38])
+def thousand_genomes_vcf(request):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        data_cache = RealData(GRCh_version=request.param)
+
+    return VariantFile(data_cache / data_cache._thousand_genome_vcf)
+
+
+@pytest.mark.real_data
+@pytest.mark.parametrize("chrom", [1, "1", "chr1", "X", "chrX"])
+def test_vcf_multiple_chrom_codes(thousand_genomes_vcf, chrom):
+    # GIVEN: Thousand Genomes VCF
+    # THEN: I can fetch with different chromosome codes and they will be
+    # handled gracefully.
+    assert thousand_genomes_vcf.fetch(chrom, 1_000_000, 1_001_000)
+
+
+@pytest.mark.real_data
+@pytest.mark.parametrize("chrom", [-1, "XY", "NA"])
+def test_vcf_nonsense_chrom(thousand_genomes_vcf, chrom):
+    # GIVEN: Thousand Genomes VCF
+    # THEN: I can fetch with different chromosome codes and they will be
+    # handled gracefully.
+    with pytest.raises(ValueError):
+        thousand_genomes_vcf.fetch(chrom, 1_000_000, 1_001_000)
+
+
+@pytest.mark.real_data
+@pytest.mark.parametrize("chrom", [1, "chr2", "X"])
+def test_contains_contig(thousand_genomes_vcf, chrom):
+    assert thousand_genomes_vcf.contains_contig(chrom)
+
+
+@pytest.mark.real_data
+@pytest.mark.parametrize("chrom", ["A", 42, "NA"])
+def test_not_contains_contig(thousand_genomes_vcf, chrom):
+    assert not thousand_genomes_vcf.contains_contig(chrom)


### PR DESCRIPTION
Adds a thin wrapper around the `pysam.VariantFile` to add some new functionality and error handling.