### PR TITLE
Change cgr-snakemake cli to directly call snakemake's cli

### DIFF
--- a/src/cgr_gwas_qc/cli/__init__.py
+++ b/src/cgr_gwas_qc/cli/__init__.py
@@ -11,7 +11,14 @@ from cgr_gwas_qc.cli import config, pre_flight, snakemake
 app = typer.Typer(add_completion=False, help=__doc__)
 app.command("config")(config.main)
 app.command("pre-flight")(pre_flight.main)
-app.command("snakemake")(snakemake.main)
+app.command(
+    "snakemake",
+    context_settings={
+        "allow_extra_args": True,
+        "ignore_unknown_options": True,
+        "help_option_names": [],
+    },
+)(snakemake.main)
 
 
 if __name__ == "__main__":

--- a/src/cgr_gwas_qc/cli/snakemake.py
+++ b/src/cgr_gwas_qc/cli/snakemake.py
@@ -1,92 +1,32 @@
-import os
-
+import snakemake
 import typer
-from snakemake import snakemake
 
-from cgr_gwas_qc import load_config
 from cgr_gwas_qc.config import ConfigMgr
 
-app = typer.Typer(add_completion=False)
 
-
-def fmt_doc_string(func):
-    """Hack to add full path to snakefile in the doc string."""
-    func.__doc__ = func.__doc__.format(ConfigMgr.SNAKEFILE)
-    return func
-
-
-@app.command(name="snakemake")
-@fmt_doc_string
-def main(
-    cores: int = typer.Option(
-        1,
-        "--cores",
-        "--jobs",
-        "-j",
-        help="the number of provided cores (ignored when using cluster support)",
-    ),
-    local_cores: int = typer.Option(
-        1,
-        "--local-cores",
-        help="the number of provided local cores if in cluster mode (ignored without cluster support)",
-    ),
-    dryrun: bool = typer.Option(
-        False, "--dry-run", "--dryrun", "-n", help="only dry-run the workflow"
-    ),
-    touch: bool = typer.Option(
-        False, "--touch", "-t", help="only touch all output files if present"
-    ),
-    forcetargets: bool = typer.Option(
-        False, "--force", "-f", help="force given targets to be re-created"
-    ),
-    forceall: bool = typer.Option(
-        False, "--forceall", "-F", help="force all output files to be re-created"
-    ),
-    quiet: bool = typer.Option(
-        False, "--quiet", "-q", help="do not print any default job information"
-    ),
-    keepgoing: bool = typer.Option(False, "--keep-going", "-k", help=" keep going upon errors"),
-    unlock: bool = typer.Option(False, help=" just unlock the working directory"),
-    conda_cleanup_envs: bool = typer.Option(
-        False, "--conda-cleanup-envs", help="just cleanup unused conda environments"
-    ),
-    use_conda: bool = typer.Option(
-        False, "--use-conda", help="use conda environments for each job"
-    ),
-    conda_create_envs_only: bool = typer.Option(
-        False,
-        "--conda-create-envs-only",
-        help="if specified, only builds the conda environments specified for each job, then exits.",
-    ),
-):
+def main(ctx: typer.Context):
     """Run the Gwas Qc Pipeline using Snakemake.
 
-    We only expose a few common snakemake options. If you want to run
-    snakemake directly then use:
+    This is a wrapper around snakemake. It will pre-pend the `-s`
+    option to point at `cgr_gwas_qc/workflow/Snakemake`. This is how the user
+    should run snakemake locally.
+    """
+    args = ctx.args
 
-        snakemake -s {} OPTIONS TARGETS
-   """
+    if not is_arg(args, ["-h", "--help"]):
+        check_and_prepend_arg(args, ["-j", "--cores", "--jobs"], "1")
+        check_and_prepend_arg(args, ["-s", "--snakefile"], ConfigMgr.SNAKEFILE.as_posix())
 
-    cfg = load_config()
-    workdir = os.getcwd()
-
-    snakemake(
-        cfg.SNAKEFILE,
-        cores=cores,
-        local_cores=local_cores,
-        workdir=workdir,
-        dryrun=dryrun,
-        touch=touch,
-        forcetargets=forcetargets,
-        forceall=forceall,
-        quiet=quiet,
-        keepgoing=keepgoing,
-        unlock=unlock,
-        conda_cleanup_envs=conda_cleanup_envs,
-        use_conda=use_conda,
-        conda_create_envs_only=conda_create_envs_only,
-    )
+    print(f"cgr running: snakemake {' '.join(args)}")
+    snakemake.main(args)
 
 
-if __name__ == "__main__":
-    app()
+def is_arg(args, options):
+    """Check if an option is already in the argument list."""
+    return any(option in args for option in options)
+
+
+def check_and_prepend_arg(args, options, value):
+    """Prepend an option to the front of the arg list."""
+    if not is_arg(args, options):
+        [args.insert(i, v) for i, v in enumerate([options[0], value])]


### PR DESCRIPTION
The snakemake CLI has a ton of options. I had implemented a subset of these options in `cgr-snakemake` but I kept needing additional options. Here I change `cgr-snakemake` to inject `-s </path/to/snakefile/>` and then directly pass to snakemake's main entry point `snakemake.main`. This changes this into a virtually transparent wrapper of snakemake giving the user access to all options and help.


Closes #5