### PR TITLE
Add num_samples and num_snps to config (issue74)

### DIFF
--- a/src/cgr_gwas_qc/models/config/__init__.py
+++ b/src/cgr_gwas_qc/models/config/__init__.py
@@ -39,6 +39,13 @@ class Config(BaseModel):
     sample_sheet: Path = Field(
         Path("sample_sheet.csv"), description="Path to the sample manifest from LIMs."
     )
+    num_samples: Optional[int] = Field(
+        None, help="Number of samples, automatically calculated from the sample sheet."
+    )
+    num_snps: Optional[int] = Field(
+        None,
+        help="Number of markers, automatically calculated from the `reference_files.illumina_manifest_file",
+    )
     reference_files: ReferenceFiles = ReferenceFiles()  # Paths to reference files.
     user_files: UserFiles = UserFiles()  # Paths to user provided files.
     software_params: SoftwareParams = SoftwareParams()  # Various software parameters.

--- a/src/cgr_gwas_qc/workflow/modules/common.smk
+++ b/src/cgr_gwas_qc/workflow/modules/common.smk
@@ -12,12 +12,6 @@ wildcard_constraints:
     ld="0\.\d+",
 
 
-def get_numSNPs():
-    from cgr_gwas_qc.parsers.illumina import BeadPoolManifest
-
-    return BeadPoolManifest(cfg.config.reference_files.illumina_manifest_file).num_loci
-
-
 def rule_group(wildcards):
     prefix = wildcards.get("prefix", "").replace("/", "_")
     name = wildcards.get("name", "")

--- a/src/cgr_gwas_qc/workflow/modules/sample_level_qc.smk
+++ b/src/cgr_gwas_qc/workflow/modules/sample_level_qc.smk
@@ -163,7 +163,7 @@ if (
             adpc=rules.per_sample_gtc_to_adpc.output.adpc,
             abf=rules.pull_1KG_allele_b_freq.output.abf_file,
         params:
-            snps=get_numSNPs(),
+            snps=cfg.config.num_snps,
         output:
             temp("sample_level/per_sample_contamination_test/{Sample_ID}.contam.out"),
         resources:

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,0 +1,9 @@
+from cgr_gwas_qc.cli.config import get_number_samples, get_number_snps
+
+
+def test_get_number_samples(sample_sheet_file):
+    assert 4 == get_number_samples(sample_sheet_file)
+
+
+def test_get_number_snps(bpm_file):
+    assert 2000 == get_number_snps(bpm_file)

--- a/tests/workflow/modules/test_common.py
+++ b/tests/workflow/modules/test_common.py
@@ -118,7 +118,7 @@ def test_eigensoft_convert(tmp_path, conda_envs):
         )
     )
     # WHEN:
-    run_snakemake(tmp_path)
+    run_snakemake(tmp_path, keep_temp=True)
 
     # THEN: the files exists
     file_hashes_equal(

--- a/tests/workflow/modules/test_sample_level_qc.py
+++ b/tests/workflow/modules/test_sample_level_qc.py
@@ -242,7 +242,7 @@ def test_per_sample_verifyIDintensity_contamination(tmp_path, conda_envs):
             "production_outputs/GSAMD-24v1-0_20011747_A1.AF.abf.txt",
             "sample_level/GSAMD-24v1-0_20011747_A1.AF.abf.txt",
         )
-        .make_config()
+        .make_config(num_snps=700078)
         .make_snakefile(
             """
             from cgr_gwas_qc import load_config
@@ -293,7 +293,7 @@ def test_contamination_test_with_missing_abf_values(tmp_path, conda_envs):
         .add_reference_files(copy=False)
         .add_user_files(entry_point="gtc", copy=False)
         .copy("production_outputs/contam", "sample_level/per_sample_adpc")
-        .make_config()
+        .make_config(num_snps=700078)
         .make_snakefile(
             """
             from cgr_gwas_qc import load_config
@@ -351,7 +351,7 @@ def test_contamination_test_with_missing_adpc_values(tmp_path, conda_envs):
             "production_outputs/GSAMD-24v1-0_20011747_A1.AF.abf.txt",
             "sample_level/GSAMD-24v1-0_20011747_A1.AF.abf.txt",
         )
-        .make_config()
+        .make_config(num_snps=700078)
         .make_snakefile(
             """
             from cgr_gwas_qc import load_config


### PR DESCRIPTION
Adds two new config options (num_samples, num_snps) to the top level config. Adds logic to `cgr config` to auto fill in these values. 

Closes #74