### PR TITLE
Add output_pattern config option (issue26)

### DIFF
--- a/src/cgr_gwas_qc/models/config/user_files.py
+++ b/src/cgr_gwas_qc/models/config/user_files.py
@@ -10,6 +10,10 @@ class UserFiles(BaseModel):
     The GWAS QC Pipeline requires GTC or IDAT files.
     """
 
+    output_pattern: str = Field(
+        "{prefix}/{file_type}.{ext}", description="File naming pattern for deliverable files."
+    )
+
     idat_pattern: Optional["Idat"]
 
     # GTC

--- a/src/cgr_gwas_qc/workflow/modules/delivery.smk
+++ b/src/cgr_gwas_qc/workflow/modules/delivery.smk
@@ -1,13 +1,6 @@
 import pandas as pd
 
 
-def use_lims_name(pth, file_type, ext="csv"):
-    if "AnalysisManifest" in cfg.sample_sheet_file.stem:
-        lims_name = cfg.sample_sheet_file.stem.replace("AnalysisManifest", file_type)
-        return f"{pth}/{lims_name}.{ext}"
-    return f"{pth}/{file_type}.{ext}"
-
-
 ################################################################################
 # Files For Lab
 ################################################################################
@@ -15,7 +8,9 @@ rule lab_sample_level_qc_report:
     input:
         "sample_level/qc_summary.csv",
     output:
-        use_lims_name("files_for_lab", "all_sample_qc"),
+        cfg.config.user_files.output_pattern.format(
+            prefix="files_for_lab", file_type="all_sample_qc", ext="csv"
+        ),
     shell:
         "cp {input[0]} {output[0]}"
 
@@ -24,7 +19,9 @@ rule lab_lims_upload:
     input:
         "sample_level/qc_summary.csv",
     output:
-        use_lims_name("files_for_lab", "LimsUpload"),
+        cfg.config.user_files.output_pattern.format(
+            prefix="files_for_lab", file_type="LimsUpload", ext="csv"
+        ),
     run:
         (
             pd.read_csv(input[0])
@@ -52,7 +49,9 @@ rule lab_identifiler_needed:
     input:
         "sample_level/qc_summary.csv",
     output:
-        use_lims_name("files_for_lab", "Identifiler"),
+        cfg.config.user_files.output_pattern.format(
+            prefix="files_for_lab", file_type="Identifiler", ext="csv"
+        ),
     run:
         (
             pd.read_csv(input[0])
@@ -77,7 +76,9 @@ rule lab_known_replicates:
     input:
         "sample_level/concordance/KnownReplicates.csv",
     output:
-        use_lims_name("files_for_lab", "KnownReplicates"),
+        cfg.config.user_files.output_pattern.format(
+            prefix="files_for_lab", file_type="KnownReplicates", ext="csv"
+        ),
     shell:
         "cp {input[0]} {output[0]}"
 
@@ -86,7 +87,9 @@ rule lab_unknown_replicates:
     input:
         "sample_level/concordance/UnknownReplicates.csv",
     output:
-        use_lims_name("files_for_lab", "UnknownReplicates"),
+        cfg.config.user_files.output_pattern.format(
+            prefix="files_for_lab", file_type="UnknownReplicates", ext="csv"
+        ),
     shell:
         "cp {input[0]} {output[0]}"
 
@@ -98,7 +101,9 @@ rule deliver_manifest:
     input:
         cfg.sample_sheet_file.as_posix(),
     output:
-        use_lims_name("deliver", "AnalysisManifest"),
+        cfg.config.user_files.output_pattern.format(
+            prefix="deliver", file_type="AnalysisManifest", ext="csv"
+        ),
     shell:
         "cp {input[0]} {output[0]}"
 
@@ -165,18 +170,3 @@ rule deliver_subject_list:
             .rename({"Group_By_Subject_ID": "Subject_ID"}, axis=1)
             .to_csv(output[0], index=False)
         )
-
-
-rule deliver_readme:
-    output:
-        "deliver/README",
-
-
-rule deliver_summary_writeup:
-    output:
-        use_lims_name("deliver", "QC_Report", "docx"),
-
-
-rule deliver_summary_table:
-    output:
-        use_lims_name("deliver", "QC_Report", "xlsx"),

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,5 +1,18 @@
-from cgr_gwas_qc.cli.config import get_number_snps
+import pytest
+
+from cgr_gwas_qc.cli.config import get_number_snps, get_output_pattern
 
 
 def test_get_number_snps(bpm_file):
     assert 2000 == get_number_snps(bpm_file)
+
+
+@pytest.mark.parametrize(
+    "sample_sheet_name,output_pattern",
+    [
+        ("test_AnalysisManifest_0123.csv", "{prefix}/test_{file_type}_0123.{ext}"),
+        ("test_0123.csv", "{prefix}/{file_type}.{ext}"),
+    ],
+)
+def test_get_output_pattern(sample_sheet_name, output_pattern):
+    assert output_pattern == get_output_pattern(sample_sheet_name)

--- a/tests/workflow/modules/test_delivery.py
+++ b/tests/workflow/modules/test_delivery.py
@@ -28,7 +28,10 @@ def files_for_upload(tmp_path_factory, qc_summary):
             "production_outputs/concordance/UnknownReplicates.csv",
             "sample_level/concordance/UnknownReplicates.csv",
         )
-        .make_config(sample_sheet="SR001-001_00_AnalysisManifest_0000000.csv")
+        .make_config(
+            sample_sheet="SR001-001_00_AnalysisManifest_0000000.csv",
+            user_files=dict(output_pattern="{prefix}/SR001-001_00_{file_type}_0000000.{ext}"),
+        )
         .make_snakefile(
             """
             from cgr_gwas_qc import load_config
@@ -166,7 +169,10 @@ def files_for_deliver(tmp_path_factory, qc_summary):
         .copy("production_outputs/subject_level/samples.fam", "subject_level/samples.fam")
         # Use CGR manifest naming scheme
         .copy("original_data/manifest_full.csv", "SR001-001_00_AnalysisManifest_0000000.csv",)
-        .make_config(sample_sheet="SR001-001_00_AnalysisManifest_0000000.csv")
+        .make_config(
+            sample_sheet="SR001-001_00_AnalysisManifest_0000000.csv",
+            user_files=dict(output_pattern="{prefix}/SR001-001_00_{file_type}_0000000.{ext}"),
+        )
         .make_snakefile(
             """
             from cgr_gwas_qc import load_config


### PR DESCRIPTION
Adds user_files.output_pattern to the config and makes use of this option when creating deliverables. Removes the need for `user_lims_name`.

Closes #26