### PR TITLE
Refactor pre-flight checks

### DIFF
--- a/src/cgr_gwas_qc/cli/pre_flight.py
+++ b/src/cgr_gwas_qc/cli/pre_flight.py
@@ -5,15 +5,15 @@ from pathlib import Path
 from textwrap import indent
 from typing import Dict, List, Mapping, Optional, Sequence, Set
 
-import pandas as pd
 import typer
+from pydantic.error_wrappers import ValidationError
 
-from cgr_gwas_qc import load_config
-from cgr_gwas_qc.config import ConfigMgr, config_to_yaml
+from cgr_gwas_qc import yaml
+from cgr_gwas_qc.config import config_to_yaml
 from cgr_gwas_qc.exceptions import GwasQcValidationError
-from cgr_gwas_qc.models.config import ReferenceFiles
-from cgr_gwas_qc.models.config.user_files import UserFiles
+from cgr_gwas_qc.models.config import Config, ReferenceFiles, UserFiles
 from cgr_gwas_qc.parsers.illumina.IlluminaBeadArrayFiles import BeadPoolManifest
+from cgr_gwas_qc.parsers.sample_sheet import SampleSheet
 from cgr_gwas_qc.validators import bgzip, bpm, gtc, idat, sample_sheet
 
 app = typer.Typer(add_completion=False)
@@ -23,6 +23,7 @@ ProblemFile = namedtuple("ProblemFile", "Sample_ID,reason,file_type,filename")
 
 @app.command()
 def main(
+    config_file: Path = typer.Option("config.yml", exists=True, readable=True),
     reference_check: bool = True,
     user_files_check: bool = True,
     update_config: bool = True,
@@ -34,27 +35,66 @@ def main(
     and GTC files. For Idat and GTC files, the user provided file name
     pattern is extended using the columns in the sample sheet.
     """
-    cfg = load_config()
-    check_sample_sheet(cfg.sample_sheet_file)
+    config = check_config(config_file)
+    sample_sheet = check_sample_sheet(config.sample_sheet).remove_Sample_IDs(
+        config.Sample_IDs_to_remove
+    )
 
     if reference_check:
-        check_reference_files(cfg.config.reference_files)
+        check_reference_files(config.reference_files)
 
     problem_samples = None
     if user_files_check:
-        problem_samples = check_user_files(cfg.config.user_files, cfg.ss, threads)
+        problem_samples = check_user_files(config.user_files, sample_sheet, threads)
 
     if update_config:
         # Update the config file with problem samples and re-calculate values
-        update_config_file(cfg, problem_samples)
+        update_config_file(config, sample_sheet, problem_samples)
 
 
-def check_sample_sheet(ss: Path):
+def check_config(config_file: Path) -> Config:
     try:
-        sample_sheet.validate(ss)
-        typer.secho(f"Sample Sheet OK ({ss.as_posix()})", fg=typer.colors.GREEN)
+        data = yaml.load(config_file)
+        return Config.parse_obj(data)
+    except Exception as err:
+        if isinstance(err, OSError):
+            msg = err.args[1]
+        elif isinstance(err, ValidationError):
+            msg = str(err.args[0][0].exc).replace("\n", " ")
+        else:
+            msg = err.args[0]
+
+        typer.secho(
+            (
+                f"Config ERROR: ({config_file})\n\t{msg}\n"
+                "Exiting... Cannot continue without a valid config file."
+            ),
+            fg=typer.colors.RED,
+        )
+        raise SystemExit
+
+
+def check_sample_sheet(filename) -> SampleSheet:
+    try:
+        sample_sheet.validate(filename)
+        typer.secho(f"Sample Sheet OK ({filename.as_posix()})", fg=typer.colors.GREEN)
     except sample_sheet.SampleSheetNullRowError:
-        typer.secho(f"Sample Sheet Contains Empty Rows ({ss.as_posix()})", fg=typer.colors.YELLOW)
+        typer.secho(
+            f"Sample Sheet WARNING: Contains Empty Rows ({filename.as_posix()})",
+            fg=typer.colors.YELLOW,
+        )
+    except Exception as err:
+        msg = err.args[0] if len(err.args) == 1 else err.args[1]
+        typer.secho(
+            (
+                f"Sample Sheet ERROR: ({filename.as_posix()})\n\t{msg}\n"
+                "Exiting... Cannot continue without a valid sample sheet."
+            ),
+            fg=typer.colors.RED,
+        )
+        raise SystemExit
+
+    return SampleSheet(filename)
 
 
 def check_reference_files(reference_files: ReferenceFiles):
@@ -62,29 +102,34 @@ def check_reference_files(reference_files: ReferenceFiles):
     try:
         bpm.validate(bpm_)  # type: ignore
         typer.secho(f"BPM OK ({bpm_})", fg=typer.colors.GREEN)
-    except Exception:
-        typer.secho(f"BPM FAILED ({bpm_})", fg=typer.colors.RED)
+    except Exception as err:
+        msg = err.args[0] if len(err.args) == 1 else err.args[1]
+        typer.secho(f"BPM ERROR: {msg} ({bpm_})", fg=typer.colors.RED)
 
     vcf_ = reference_files.thousand_genome_vcf
     try:
         bgzip.validate(vcf_)  # type: ignore
         typer.secho(f"VCF OK ({vcf_})", fg=typer.colors.GREEN)
-    except Exception:
-        typer.secho(f"VCF FAILED ({vcf_})", fg=typer.colors.RED)
+    except Exception as err:
+        msg = err.args[0] if len(err.args) == 1 else err.args[1]
+        typer.secho(f"VCF ERROR: {msg} ({vcf_})", fg=typer.colors.RED)
 
     tbi_ = reference_files.thousand_genome_tbi
     try:
         bgzip.validate(tbi_)  # type: ignore
         typer.secho(f"VCF.TBI OK ({tbi_})", fg=typer.colors.GREEN)
-    except Exception:
-        typer.secho(f"VCF.TBI FAILED ({tbi_})", fg=typer.colors.RED)
+    except Exception as err:
+        msg = err.args[0] if len(err.args) == 1 else err.args[1]
+        typer.secho(f"VCF.TBI ERROR: {msg} ({tbi_})", fg=typer.colors.RED)
 
 
-def check_user_files(user_files: UserFiles, sample_sheet: pd.DataFrame, threads: int) -> Set[str]:
+def check_user_files(user_files: UserFiles, sample_sheet: SampleSheet, threads: int) -> Set[str]:
     # Here I use multiple processors speed up processing of user files
     pool = mp.Pool(threads)
     args = list(
-        product([user_files], [record._asdict() for record in sample_sheet.itertuples(index=False)])
+        product(
+            [user_files], [record._asdict() for record in sample_sheet.data.itertuples(index=False)]
+        )
     )
     typer.secho("Checking user files for {:,} samples.".format(len(args)))
     futures = pool.starmap(_check_user_files, args)
@@ -92,23 +137,23 @@ def check_user_files(user_files: UserFiles, sample_sheet: pd.DataFrame, threads:
         problem_user_files = []
         for results in bar:
             problem_user_files.extend([problem for problem in results if problem])
-        _pretty_print_problems(problem_user_files)
+        _pretty_print_user_problems(problem_user_files)
 
     return {problem.Sample_ID for problem in problem_user_files}
 
 
-def update_config_file(cfg: ConfigMgr, problem_samples: Optional[Set[str]]):
+def update_config_file(
+    config: Config, sample_sheet: SampleSheet, problem_samples: Optional[Set[str]]
+):
     if problem_samples:
         # Add problem samples and update num_samples
-        cfg.config.Sample_IDs_to_remove = list(problem_samples)
-        cfg.config.num_samples = cfg.ss.query("Sample_ID not in @problem_samples").shape[0]
+        config.Sample_IDs_to_remove = list(problem_samples)
+        config.num_samples = sample_sheet.data.query("Sample_ID not in @problem_samples").shape[0]
 
-    if cfg.config.num_snps == 0:
-        cfg.config.num_snps = BeadPoolManifest(
-            cfg.config.reference_files.illumina_manifest_file
-        ).num_loci
+    if config.num_snps == 0:
+        config.num_snps = BeadPoolManifest(config.reference_files.illumina_manifest_file).num_loci
 
-    config_to_yaml(cfg.config)
+    config_to_yaml(config)
 
 
 def _check_user_files(user_files: UserFiles, record: Mapping) -> List[Optional[ProblemFile]]:
@@ -150,10 +195,10 @@ def _check_gtc(filename: str, sample_id: str) -> Optional[ProblemFile]:
     return None
 
 
-def _pretty_print_problems(problems: Sequence[ProblemFile]):
+def _pretty_print_user_problems(problems: Sequence[ProblemFile]):
     if idat_red := _filter_list(problems, "idat_red"):
         typer.secho(
-            "There was a problem with these Idat red files:\n{}".format(
+            "IDAT RED ERROR: There was a problem with these files:\n{}".format(
                 _pretty_print_paths(idat_red)
             ),
             fg=typer.colors.RED,
@@ -163,7 +208,7 @@ def _pretty_print_problems(problems: Sequence[ProblemFile]):
 
     if idat_green := _filter_list(problems, "idat_green"):
         typer.secho(
-            "There was a problem with these Idat green files:\n{}".format(
+            "IDAT GREEN ERROR: There was a problem with these files:\n{}".format(
                 _pretty_print_paths(idat_green)
             ),
             fg=typer.colors.RED,
@@ -173,7 +218,7 @@ def _pretty_print_problems(problems: Sequence[ProblemFile]):
 
     if gtc := _filter_list(problems, "gtc"):
         typer.secho(
-            "There was a problem with these gtc files:\n{}".format(_pretty_print_paths(gtc)),
+            "GTC ERROR: There was a problem with these files:\n{}".format(_pretty_print_paths(gtc)),
             fg=typer.colors.RED,
         )
     else:

--- a/src/cgr_gwas_qc/cli/pre_flight.py
+++ b/src/cgr_gwas_qc/cli/pre_flight.py
@@ -1,21 +1,33 @@
-from collections import defaultdict
+import multiprocessing as mp
+from collections import defaultdict, namedtuple
+from itertools import product
 from pathlib import Path
 from textwrap import indent
-from typing import Dict, List
+from typing import Dict, List, Mapping, Optional, Sequence, Set
 
+import pandas as pd
 import typer
-from snakemake.rules import expand
 
 from cgr_gwas_qc import load_config
+from cgr_gwas_qc.config import ConfigMgr, config_to_yaml
 from cgr_gwas_qc.exceptions import GwasQcValidationError
 from cgr_gwas_qc.models.config import ReferenceFiles
-from cgr_gwas_qc.validators import bgzip, bpm, gtc, sample_sheet
+from cgr_gwas_qc.models.config.user_files import UserFiles
+from cgr_gwas_qc.parsers.illumina.IlluminaBeadArrayFiles import BeadPoolManifest
+from cgr_gwas_qc.validators import bgzip, bpm, gtc, idat, sample_sheet
 
 app = typer.Typer(add_completion=False)
 
+ProblemFile = namedtuple("ProblemFile", "Sample_ID,reason,file_type,filename")
+
 
 @app.command()
-def main(reference_check: bool = True, gtc_check: bool = True, idat_check: bool = False):
+def main(
+    reference_check: bool = True,
+    user_files_check: bool = True,
+    update_config: bool = True,
+    threads: int = 4,
+):
     """Pre-flight checks to make sure user input files are readable and complete.
 
     Pre-flight checks include the Sample Sheet, reference files, Idat files,
@@ -28,13 +40,13 @@ def main(reference_check: bool = True, gtc_check: bool = True, idat_check: bool 
     if reference_check:
         check_reference_files(cfg.config.reference_files)
 
-    if idat_check:
-        typer.secho("Idat pre-flight is not impelmented yet.", fg=typer.colors.YELLOW)
-        # check_idat_files(expand(cfg.config.file_patterns.idat.red, **cfg.ss.to_dict("list")), "Red")
-        # check_idat_files(expand(cfg.config.file_patterns.idat.grn, **cfg.ss.to_dict("list")), "Green")
+    problem_samples = None
+    if user_files_check:
+        problem_samples = check_user_files(cfg.config.user_files, cfg.ss, threads)
 
-    if gtc_check:
-        check_gtc_files(expand(cfg.config.user_files.gtc_pattern, zip, **cfg.ss.to_dict("list")))
+    if update_config:
+        # Update the config file with problem samples and re-calculate values
+        update_config_file(cfg, problem_samples)
 
 
 def check_sample_sheet(ss: Path):
@@ -68,52 +80,115 @@ def check_reference_files(reference_files: ReferenceFiles):
         typer.secho(f"VCF.TBI FAILED ({tbi_})", fg=typer.colors.RED)
 
 
-def check_idat_files(files: List[str], color: str):
-    problems = defaultdict(list)
-    for idat in files:
-        try:
-            raise NotImplementedError
-        except FileNotFoundError:
-            problems["FileNotFound"].append(idat)
-        except PermissionError:
-            problems["FileNotReadable"].append(idat)
-        except GwasQcValidationError as err:
-            problems[err.args[0]].append(idat)
+def check_user_files(user_files: UserFiles, sample_sheet: pd.DataFrame, threads: int) -> Set[str]:
+    # Here I use multiple processors speed up processing of user files
+    pool = mp.Pool(threads)
+    args = list(
+        product([user_files], [record._asdict() for record in sample_sheet.itertuples(index=False)])
+    )
+    typer.secho("Checking files for {:,} samples.".format(len(args)))
+    futures = pool.starmap(_check_user_files, args)
+    with typer.progressbar(futures, length=len(args)) as bar:
+        problem_user_files = []
+        for results in bar:
+            problem_user_files.extend([problem for problem in results if problem])
+        _pretty_print_problems(problem_user_files)
 
-    if problems:
-        typer.echo(
-            "There was a problem with these Idat {} files:\n{}".format(
-                color, pretty_print_paths(problems)
-            )
+    return {problem.Sample_ID for problem in problem_user_files}
+
+
+def update_config_file(cfg: ConfigMgr, problem_samples: Optional[Set[str]]):
+    if problem_samples:
+        # Add problem samples and update num_samples
+        cfg.config.Sample_IDs_to_remove = list(problem_samples)
+        cfg.config.num_samples = cfg.ss.query("Sample_ID not in @problem_samples").shape[0]
+
+    if cfg.config.num_snps == 0:
+        cfg.config.num_snps = BeadPoolManifest(
+            cfg.config.reference_files.illumina_manifest_file
+        ).num_loci
+
+    config_to_yaml(cfg.config)
+
+
+def _check_user_files(user_files: UserFiles, record: Mapping) -> List[Optional[ProblemFile]]:
+    sample_id = record["Sample_ID"]
+    problems = []
+
+    if user_files.idat_pattern:
+        problems.append(_check_idat(user_files.idat_pattern.red.format(**record), "red", sample_id))
+        problems.append(
+            _check_idat(user_files.idat_pattern.green.format(**record), "green", sample_id)
         )
-    else:
-        typer.echo(f"Idat {color} Files OK.")
+    if user_files.gtc_pattern:
+        problems.append(_check_gtc(user_files.gtc_pattern.format(**record), sample_id))
+
+    return problems
 
 
-def check_gtc_files(files: List[str]):
-    problems = defaultdict(list)
-    typer.echo("Processing GTC Files")
-    with typer.progressbar(files) as progress:
-        for gtc_ in progress:
-            try:
-                gtc.validate(Path(gtc_))
-            except FileNotFoundError:
-                problems["FileNotFound"].append(gtc_)
-            except PermissionError:
-                problems["FileNotReadable"].append(gtc_)
-            except GwasQcValidationError as err:
-                problems[err.args[0]].append(gtc_)
+def _check_idat(filename: str, color: str, sample_id: str) -> Optional[ProblemFile]:
+    try:
+        idat.validate(Path(filename))
+    except FileNotFoundError:
+        return ProblemFile(sample_id, "FileNotFound", f"idat_{color}", filename)
+    except PermissionError:
+        return ProblemFile(sample_id, "Permissions", f"idat_{color}", filename)
+    except GwasQcValidationError as err:
+        return ProblemFile(sample_id, err.args[0], f"idat_{color}", filename)
+    return None
 
-    if problems:
+
+def _check_gtc(filename: str, sample_id: str) -> Optional[ProblemFile]:
+    try:
+        gtc.validate(Path(filename))
+    except FileNotFoundError:
+        return ProblemFile(sample_id, "FileNotFound", "gtc", filename)
+    except PermissionError:
+        return ProblemFile(sample_id, "Permissions", "gtc", filename)
+    except GwasQcValidationError as err:
+        return ProblemFile(sample_id, err.args[0], "gtc", filename)
+    return None
+
+
+def _pretty_print_problems(problems: Sequence[ProblemFile]):
+    if idat_red := _filter_list(problems, "idat_red"):
         typer.secho(
-            "There was a problem with these GTC files:\n{}".format(pretty_print_paths(problems)),
+            "There was a problem with these Idat red files:\n{}".format(
+                _pretty_print_paths(idat_red)
+            ),
             fg=typer.colors.RED,
         )
     else:
-        typer.secho(f"{len(files):,} GTC Files OK.", fg=typer.colors.GREEN)
+        typer.secho("IDAT RED Files OK.", fg=typer.colors.GREEN)
+
+    if idat_green := _filter_list(problems, "idat_green"):
+        typer.secho(
+            "There was a problem with these Idat green files:\n{}".format(
+                _pretty_print_paths(idat_green)
+            ),
+            fg=typer.colors.RED,
+        )
+    else:
+        typer.secho("IDAT GREEN Files OK.", fg=typer.colors.GREEN)
+
+    if gtc := _filter_list(problems, "gtc"):
+        typer.secho(
+            "There was a problem with these gtc files:\n{}".format(_pretty_print_paths(gtc)),
+            fg=typer.colors.RED,
+        )
+    else:
+        typer.secho("GTC Files OK.", fg=typer.colors.GREEN)
 
 
-def pretty_print_paths(data: Dict[str, List[str]]) -> str:
+def _filter_list(problems: Sequence[ProblemFile], file_type: str) -> Dict[str, List[str]]:
+    res = defaultdict(list)
+    for problem in problems:
+        if problem.file_type == file_type:
+            res[problem.reason].append(problem.filename)
+    return res
+
+
+def _pretty_print_paths(data: Mapping[str, Sequence[str]]) -> str:
     """For each exception output a list of files nicely."""
     output = ""
     for k, v in data.items():

--- a/src/cgr_gwas_qc/cli/pre_flight.py
+++ b/src/cgr_gwas_qc/cli/pre_flight.py
@@ -86,7 +86,7 @@ def check_user_files(user_files: UserFiles, sample_sheet: pd.DataFrame, threads:
     args = list(
         product([user_files], [record._asdict() for record in sample_sheet.itertuples(index=False)])
     )
-    typer.secho("Checking files for {:,} samples.".format(len(args)))
+    typer.secho("Checking user files for {:,} samples.".format(len(args)))
     futures = pool.starmap(_check_user_files, args)
     with typer.progressbar(futures, length=len(args)) as bar:
         problem_user_files = []

--- a/src/cgr_gwas_qc/config.py
+++ b/src/cgr_gwas_qc/config.py
@@ -66,8 +66,10 @@ class ConfigMgr:
         self._sample_sheet: Optional[SampleSheet] = None
 
         try:
-            self._sample_sheet = SampleSheet(self.sample_sheet_file).add_group_by_column(
-                self.config.workflow_params.subject_id_to_use
+            self._sample_sheet = (
+                SampleSheet(self.sample_sheet_file)
+                .add_group_by_column(self.config.workflow_params.subject_id_to_use)
+                .remove_Sample_IDs(self.config.Sample_IDs_to_remove)
             )
         except Exception:
             warn(f"Sample Sheet: {self.sample_sheet_file} could not be loaded.", RuntimeWarning)

--- a/src/cgr_gwas_qc/exceptions.py
+++ b/src/cgr_gwas_qc/exceptions.py
@@ -63,20 +63,39 @@ class GtcError(GwasQcValidationError):
 
 
 class GtcMagicNumberError(GtcError):
-    def __init__(self, name):
-        message = f"{name} has missing or wrong GTC magic number."
+    def __init__(self):
+        message = "Missing or wrong GTC magic number."
         super().__init__(message)
 
 
 class GtcVersionError(GtcError):
-    def __init__(self, name):
-        message = f"{name} has unknown or unsupported BPM version."
+    def __init__(self):
+        message = "Unknown or unsupported GTC version."
         super().__init__(message)
 
 
 class GtcTruncatedFileError(GtcError):
-    def __init__(self, name):
-        message = f"{name} is missing the EOF mark."
+    def __init__(self):
+        message = "Missing the EOF mark."
+        super().__init__(message)
+
+
+################################################################################
+# IDAT
+################################################################################
+class IdatError(GwasQcValidationError):
+    pass
+
+
+class IdatMagicNumberError(IdatError):
+    def __init__(self):
+        message = "Missing or wrong IDAT magic number."
+        super().__init__(message)
+
+
+class IdatTruncatedFileError(IdatError):
+    def __init__(self):
+        message = "Missing the EOF metadata."
         super().__init__(message)
 
 

--- a/src/cgr_gwas_qc/exceptions.py
+++ b/src/cgr_gwas_qc/exceptions.py
@@ -13,14 +13,14 @@ class BgzipError(GwasQcValidationError):
 
 
 class BgzipMagicNumberError(BgzipError):
-    def __init__(self, name):
-        message = f"{name} is missing the GZIP magic number."
+    def __init__(self):
+        message = "Missing the GZIP magic number."
         super().__init__(message)
 
 
 class BgzipTruncatedFileError(BgzipError):
-    def __init__(self, name):
-        message = f"{name} is missing the EOF mark."
+    def __init__(self):
+        message = "Missing GZIP EOF mark."
         super().__init__(message)
 
 
@@ -32,26 +32,26 @@ class BpmError(GwasQcValidationError):
 
 
 class BpmMagicNumberError(BpmError):
-    def __init__(self, name):
-        message = f"{name} has missing or wrong BPM magic number."
+    def __init__(self):
+        message = "Missing or wrong BPM magic number."
         super().__init__(message)
 
 
 class BpmVersionError(BpmError):
-    def __init__(self, name):
-        message = f"{name} has unknown or unsupported BPM version."
+    def __init__(self):
+        message = "Unknown or unsupported BPM version."
         super().__init__(message)
 
 
 class BpmNormalizationError(BpmError):
-    def __init__(self, name):
-        message = f"{name} has an invalid normalization ID."
+    def __init__(self):
+        message = "Invalid BPM normalization ID."
         super().__init__(message)
 
 
 class BpmEntryError(BpmError):
-    def __init__(self, name):
-        message = f"{name} has an invalid number of assay entries."
+    def __init__(self):
+        message = "Invalid BPM number of assay entries."
         super().__init__(message)
 
 
@@ -76,7 +76,7 @@ class GtcVersionError(GtcError):
 
 class GtcTruncatedFileError(GtcError):
     def __init__(self):
-        message = "Missing the EOF mark."
+        message = "Missing GTC EOF mark."
         super().__init__(message)
 
 
@@ -95,7 +95,7 @@ class IdatMagicNumberError(IdatError):
 
 class IdatTruncatedFileError(IdatError):
     def __init__(self):
-        message = "Missing the EOF metadata."
+        message = "Missing IDAT EOF metadata."
         super().__init__(message)
 
 
@@ -107,34 +107,34 @@ class SampleSheetError(GwasQcValidationError):
 
 
 class SampleSheetMissingSectionHeaderError(SampleSheetError):
-    def __init__(self, name: str, missing_headers: List[str]):
+    def __init__(self, missing_headers: List[str]):
         self.missing_headers = missing_headers
         header_str = ", ".join(missing_headers)
-        message = f"{name} is missing sections: {header_str}"
+        message = f"Sample sheet is missing sections: {header_str}"
         super().__init__(message)
 
 
 class SampleSheetTruncatedFileError(SampleSheetError):
-    def __init__(self, name: str):
-        message = f"{name} is truncated."
+    def __init__(self):
+        message = "Sample sheet is truncated."
         super().__init__(message)
 
 
 class SampleSheetNullRowError(SampleSheetError):
-    def __init__(self, name: str):
-        message = f"{name} has completely empty rows."
+    def __init__(self):
+        message = "Sample sheet has empty rows."
         super().__init__(message)
 
 
 class SampleSheetMissingRequiredColumnsError(SampleSheetError):
-    def __init__(self, name: str, missing_required_columns: List[str]):
+    def __init__(self, missing_required_columns: List[str]):
         col_str = ", ".join(missing_required_columns)
-        message = f"{name} is missing the required columns: {col_str}"
+        message = f"Sample sheet is missing required columns: {col_str}"
         super().__init__(message)
 
 
 class SampleSheetMissingValueRequiredColumnsError(SampleSheetError):
-    def __init__(self, name: str, col_w_missing_values: List[str]):
+    def __init__(self, col_w_missing_values: List[str]):
         col_str = ", ".join(col_w_missing_values)
-        message = f"{name} had missing values in required columns: {col_str}"
+        message = f"Sample sheet has missing values in required columns: {col_str}"
         super().__init__(message)

--- a/src/cgr_gwas_qc/models/config/__init__.py
+++ b/src/cgr_gwas_qc/models/config/__init__.py
@@ -1,7 +1,7 @@
 """Configuration system data models."""
 from logging import getLogger
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
 from pydantic import BaseModel, Field, validator
 
@@ -52,6 +52,7 @@ class Config(BaseModel):
     software_params: SoftwareParams = SoftwareParams()  # Various software parameters.
     workflow_params: WorkflowParams = WorkflowParams()  # Parameters to control how the workflow is run.
     env_modules: Optional[EnvModules]  # Use these HPC environmental modules."
+    Sample_IDs_to_remove: Optional[Sequence[str]]
 
     @validator("pipeline_version")
     def validate_pipeline_version(cls, v):

--- a/src/cgr_gwas_qc/parsers/sample_sheet.py
+++ b/src/cgr_gwas_qc/parsers/sample_sheet.py
@@ -104,10 +104,16 @@ class SampleSheet:
 
         return res
 
-    @staticmethod
-    def _clean_data(data) -> pd.DataFrame:
+    def _clean_data(self, data) -> pd.DataFrame:
         """Converts Data section into a dataframe."""
-        return pd.read_csv(StringIO(data), low_memory=False).dropna(how="all")
+        no_empty_rows = self._remove_empty_rows(data)
+        return pd.read_csv(StringIO(no_empty_rows), low_memory=False).dropna(how="all")
+
+    @staticmethod
+    def _remove_empty_rows(data: str) -> str:
+        data_no_empty_rows = re.sub("^,+$", "", data, flags=re.MULTILINE)
+        data_no_extra_breaks = re.sub("\n+", "\n", data_no_empty_rows)
+        return data_no_extra_breaks.lstrip()
 
     def add_group_by_column(self, col_name: Optional[str] = None) -> "SampleSheet":
         """Select which column in the sample sheet to use for subject grouping.

--- a/src/cgr_gwas_qc/parsers/sample_sheet.py
+++ b/src/cgr_gwas_qc/parsers/sample_sheet.py
@@ -2,7 +2,7 @@
 import re
 from io import StringIO
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import pandas as pd
 
@@ -140,6 +140,11 @@ class SampleSheet:
 
         self.data["Group_By_Subject_ID"] = self.data.apply(_get_subject_id, axis=1)
 
+        return self
+
+    def remove_Sample_IDs(self, sample_ids: Optional[Sequence[str]] = None) -> "SampleSheet":
+        if sample_ids:
+            self.data = self.data.query("Sample_ID not in @sample_ids")
         return self
 
 

--- a/src/cgr_gwas_qc/validators/bgzip.py
+++ b/src/cgr_gwas_qc/validators/bgzip.py
@@ -9,31 +9,19 @@ from cgr_gwas_qc.exceptions import BgzipMagicNumberError, BgzipTruncatedFileErro
 
 
 def validate(file_name: Path):
-    name = file_name.name
-    check_magic_number(name, file_name)
-    check_record_magic_number(name, file_name)
-    check_eof_marker(name, file_name)
+    check_magic_number(file_name)
+    check_eof_marker(file_name)
 
 
-def check_magic_number(name: str, file_name: Path):
+def check_magic_number(file_name: Path):
     """Bgzip is a special form of Gzip."""
     with file_name.open("rb") as fh:
         gzip_magic_number = b"\x1f\x8b"
         if fh.read(2) != gzip_magic_number:
-            raise BgzipMagicNumberError(name)
+            raise BgzipMagicNumberError
 
 
-def check_record_magic_number(name: str, file_name: Path):
-    """NOT IMPLEMENTED: Check for each record magic number.
-
-    Each record of a VCF/TBI has a magic number, but their location is
-    variable so I have not included their check here for simplicity.
-    """
-    # record_magic_number = b"\x42\x43\02"
-    pass
-
-
-def check_eof_marker(name: str, file_name: Path):
+def check_eof_marker(file_name: Path):
     """Htslib EOF mark.
 
     BAM/BCF/VCF.gz/TBI all have a EOF mark.
@@ -42,4 +30,4 @@ def check_eof_marker(name: str, file_name: Path):
         eof_mark = b"\x1f\x8b\x08\x04\x00\x00\x00\x00\x00\xff\x06\x00\x42\x43\x02\x00\x1b\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         fh.seek(-28, 2)
         if fh.read(28) != eof_mark:
-            raise BgzipTruncatedFileError(name)
+            raise BgzipTruncatedFileError

--- a/src/cgr_gwas_qc/validators/bpm.py
+++ b/src/cgr_gwas_qc/validators/bpm.py
@@ -10,23 +10,32 @@ from cgr_gwas_qc.parsers.illumina import BeadPoolManifest
 
 
 def validate(file_name: Path):
-    name = file_name.name
-
     try:
         # Illumina's parser has a bunch of different error checks, so I am just
         # using those to validate the file. However, I will throw custom errors
         # for clarity.
         BeadPoolManifest(file_name.as_posix())
     except Exception as err:
+        # Unfortunately, the BeadPoolManifest uses the base Exception. I am
+        # splitting them out to custom exceptions for easier handling.
+
+        if len(err.args) > 1 and not isinstance(err.args[0], str):
+            # I only expect the Exception to have a message, if not then just
+            # re-raise.
+            raise err
+
         if err.args[0].startswith("Invalid BPM format"):
-            raise BpmMagicNumberError(name)
-        elif err.args[0].startswith("Unknown BPM version") or err.args[0].startswith(
+            raise BpmMagicNumberError
+
+        if err.args[0].startswith("Unknown BPM version") or err.args[0].startswith(
             "Unsupported BPM version"
         ):
-            raise BpmVersionError(name)
-        elif err.args[0].startswith("Manifest format error: read invalid normalization ID"):
-            raise BpmNormalizationError(name)
-        elif err.args[0].startswith("Manifest format error: read invalid number of assay entries"):
-            raise BpmEntryError(name)
-        else:
-            raise err
+            raise BpmVersionError
+
+        if err.args[0].startswith("Manifest format error: read invalid normalization ID"):
+            raise BpmNormalizationError
+
+        if err.args[0].startswith("Manifest format error: read invalid number of assay entries"):
+            raise BpmEntryError
+
+        raise err

--- a/src/cgr_gwas_qc/validators/gtc.py
+++ b/src/cgr_gwas_qc/validators/gtc.py
@@ -5,8 +5,6 @@ from cgr_gwas_qc.parsers.illumina import GenotypeCalls
 
 
 def validate(file_name: Path):
-    name = file_name.name
-
     try:
         # Illumina's parser has a bunch of different error checks, so I am just
         # using those to validate the file. However, I will throw custom errors
@@ -14,10 +12,10 @@ def validate(file_name: Path):
         GenotypeCalls(file_name.as_posix())
     except Exception as err:
         if err.args[0] == "GTC format error: bad format identifier":
-            raise GtcMagicNumberError(name)
+            raise GtcMagicNumberError
         elif err.args[0] == "Unsupported GTC File version":
-            raise GtcVersionError(name)
+            raise GtcVersionError
         elif err.args[0] == "GTC file is incomplete":
-            raise GtcTruncatedFileError(name)
+            raise GtcTruncatedFileError
         else:
             raise err

--- a/src/cgr_gwas_qc/validators/sample_sheet.py
+++ b/src/cgr_gwas_qc/validators/sample_sheet.py
@@ -14,22 +14,21 @@ REQUIRED_COLUMNS = ["Sample_ID", "LIMS_Individual_ID"]
 
 
 def validate(file_name: Path):
-    name = file_name.name
     data = file_name.read_text()
-    check_section_headers(name, data)
-    check_file_truncation(name, data)
+    check_section_headers(data)
+    check_file_truncation(data)
 
     ss = SampleSheet(file_name)
-    check_required_columns(name, ss)
-    check_missing_values_required_columns(name, ss)
+    check_required_columns(ss)
+    check_missing_values_required_columns(ss)
 
     # Keep this check last, because I usually want to ignore it. This way if
-    # all other checks pass I can just catch the exception futher up the call
+    # all other checks pass I can just catch the exception further up the call
     # stack.
-    check_null_rows(name, data)
+    check_null_rows(data)
 
 
-def check_section_headers(name: str, data: str):
+def check_section_headers(data: str):
     """Checks that the three major section headers are present."""
     missing_headers = []
     if "[Header]" not in data:
@@ -42,10 +41,10 @@ def check_section_headers(name: str, data: str):
         missing_headers.append("Data")
 
     if missing_headers:
-        raise SampleSheetMissingSectionHeaderError(name, missing_headers)
+        raise SampleSheetMissingSectionHeaderError(missing_headers)
 
 
-def check_file_truncation(name: str, data: str):
+def check_file_truncation(data: str):
     """Checks for truncated files.
 
     Makes sure the first and last row have the same number of field
@@ -53,10 +52,10 @@ def check_file_truncation(name: str, data: str):
     """
     rows = data.splitlines()
     if rows[0].count(",") != rows[-1].count(",") or not data.endswith("\n"):
-        raise SampleSheetTruncatedFileError(name)
+        raise SampleSheetTruncatedFileError
 
 
-def check_null_rows(name: str, data: str):
+def check_null_rows(data: str):
     """Checks if there are any empty rows in the data section."""
     rows = data.splitlines()
     num_delim = rows[0].count(",")
@@ -65,10 +64,10 @@ def check_null_rows(name: str, data: str):
     data_rows = rows[data_idx:]
     null_row = "," * num_delim
     if null_row in data_rows:
-        raise SampleSheetNullRowError(name)
+        raise SampleSheetNullRowError
 
 
-def check_required_columns(name: str, ss: SampleSheet):
+def check_required_columns(ss: SampleSheet):
     """Checks if essential columns have missing values."""
 
     missing_required_columns = [
@@ -76,10 +75,10 @@ def check_required_columns(name: str, ss: SampleSheet):
     ]
 
     if missing_required_columns:
-        raise SampleSheetMissingRequiredColumnsError(name, missing_required_columns)
+        raise SampleSheetMissingRequiredColumnsError(missing_required_columns)
 
 
-def check_missing_values_required_columns(name: str, ss: SampleSheet):
+def check_missing_values_required_columns(ss: SampleSheet):
     """Checks if essential columns have missing values."""
     essential_columns = ["Sample_ID", "LIMS_Individual_ID"]
 
@@ -88,4 +87,4 @@ def check_missing_values_required_columns(name: str, ss: SampleSheet):
     ]
 
     if col_w_missing_values:
-        raise SampleSheetMissingValueRequiredColumnsError(name, col_w_missing_values)
+        raise SampleSheetMissingValueRequiredColumnsError(col_w_missing_values)

--- a/tests/cli/test_pre_flight.py
+++ b/tests/cli/test_pre_flight.py
@@ -14,8 +14,8 @@ def test_preflight_refs_only(test_data):
     #   - config
 
     with chdir(test_data.working_dir):
-        # WHEN: Run `cgr pre-flight --no-gtc-check --no-idat-check`
-        results = runner.invoke(app, ["--no-gtc-check", "--no-idat-check"])
+        # WHEN: Run `cgr pre-flight --no-user-files-check`
+        results = runner.invoke(app, ["--user-files-check"])
         # THEN: pre-flight validation passes
         assert results.exit_code == 0
 
@@ -27,7 +27,7 @@ def test_preflight_refs_and_gtc_only(test_data):
     #   - user files (GTC entry point)
     #   - config
     with chdir(test_data.working_dir):
-        # WHEN: Run `cgr pre-flight --gtc-check --no-idat-check`
-        results = runner.invoke(app, ["--gtc-check", "--no-idat-check"])
+        # WHEN: Run `cgr pre-flight`
+        results = runner.invoke(app)
         # THEN: pre-flight validation passes
         assert results.exit_code == 0

--- a/tests/cli/test_pre_flight.py
+++ b/tests/cli/test_pre_flight.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
 from typer.testing import CliRunner
 
-from cgr_gwas_qc.cli.pre_flight import app
+from cgr_gwas_qc import load_config
+from cgr_gwas_qc.cli.pre_flight import _check_user_files, app
 from cgr_gwas_qc.testing import chdir
 
 runner = CliRunner()
@@ -31,3 +34,51 @@ def test_preflight_refs_and_gtc_only(test_data):
         results = runner.invoke(app)
         # THEN: pre-flight validation passes
         assert results.exit_code == 0
+
+
+def test_check_user_files_no_problems(test_data):
+    with chdir(test_data.working_dir):
+        cfg = load_config()
+        user_files = cfg.config.user_files
+        record = dict(cfg.ss.iloc[0, :])
+        problems = [problem for problem in _check_user_files(user_files, record) if problem]
+        assert 0 == len(problems)
+
+
+def test_check_user_files_missing_idat_red(test_data):
+    with chdir(test_data.working_dir):
+        cfg = load_config()
+        user_files = cfg.config.user_files
+        record = dict(cfg.ss.iloc[0, :])
+        Path(user_files.idat_pattern.red.format(**record)).unlink()
+        problems = [problem for problem in _check_user_files(user_files, record) if problem]
+        assert 1 == len(problems)
+        assert "FileNotFound" == problems[0].reason
+        assert "idat_red" == problems[0].file_type
+
+
+def test_check_user_files_missing_gtc(test_data):
+    with chdir(test_data.working_dir):
+        cfg = load_config()
+        user_files = cfg.config.user_files
+        record = dict(cfg.ss.iloc[0, :])
+        Path(user_files.gtc_pattern.format(**record)).unlink()
+        problems = [problem for problem in _check_user_files(user_files, record) if problem]
+        assert 1 == len(problems)
+        assert "FileNotFound" == problems[0].reason
+        assert "gtc" == problems[0].file_type
+
+
+def test_check_user_files_missing_both_idat(test_data):
+    with chdir(test_data.working_dir):
+        cfg = load_config()
+        user_files = cfg.config.user_files
+        record = dict(cfg.ss.iloc[0, :])
+        Path(user_files.idat_pattern.red.format(**record)).unlink()
+        Path(user_files.idat_pattern.green.format(**record)).unlink()
+        problems = [problem for problem in _check_user_files(user_files, record) if problem]
+        assert 2 == len(problems)
+        assert "FileNotFound" == problems[0].reason
+        assert problems[0].file_type in ["idat_red", "idat_green"]
+        assert "FileNotFound" == problems[1].reason
+        assert problems[1].file_type in ["idat_red", "idat_green"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,12 @@ def qsub(monkeypatch):
 # Small Test Data (Fake)
 ##################################################################################
 @pytest.fixture(scope="session")
+def idat_file() -> Path:
+    """Returns the path to a test idat file."""
+    return Path("tests/data/illumina/idat/small_intensity.idat").absolute()
+
+
+@pytest.fixture(scope="session")
 def gtc_file() -> Path:
     """Returns the path to a test gtc file."""
     return Path("tests/data/illumina/gtc/small_genotype.gtc").absolute()

--- a/tests/validators/test_idat.py
+++ b/tests/validators/test_idat.py
@@ -1,0 +1,51 @@
+"""Test IDAT validation.
+
+IDAT validation is not well developed. It is based on me looking at the
+binary output and trying to get a sense of what makes a good IDAT file.
+"""
+import pytest
+
+from cgr_gwas_qc.validators.idat import IdatMagicNumberError, IdatTruncatedFileError, validate
+
+
+################################################################################
+# Good IDAT file validates
+################################################################################
+def test_idat_good_idat_file(idat_file):
+    # GIVEN: a good IDAT file
+    # WHEN-THEN: we validate the file it raises no errors
+    validate(idat_file)
+
+
+################################################################################
+# Error if not a IDAT file (IdatMagicNumberError)
+################################################################################
+def test_IDAT_bad_magic_number(bpm_file):
+    # GIVEN: a good bpm file
+    # WHEN-THEN: we validate it as a IDAT file it raises an error
+    with pytest.raises(IdatMagicNumberError):
+        validate(bpm_file)
+
+
+################################################################################
+# Error if file is truncated (IdatTruncatedFileError)
+################################################################################
+@pytest.fixture(params=[50, 100])
+def truncated_idat(tmp_path, idat_file, request):
+    """Returns the path to a truncated IDAT file.
+
+    Removes the last ``request.param`` bytes from a test IDAT file and save
+    it. Then returns the path to this file.
+    """
+    data = idat_file.read_bytes()
+    trunc_file = tmp_path / "truncated.idat"
+    with trunc_file.open("wb") as fh:
+        fh.write(data[: -request.param])
+    return trunc_file
+
+
+def test_truncated_file(truncated_idat):
+    # GIVEN: a truncated IDAT file missing a 50+ bytes from the end
+    # WHEN-THEN: we validate the file it raises a truncation error
+    with pytest.raises(IdatTruncatedFileError):
+        validate(truncated_idat)

--- a/tests/validators/test_sample_sheet.py
+++ b/tests/validators/test_sample_sheet.py
@@ -56,7 +56,7 @@ def test_missing_sections(data: str):
     # GIVEN: a sample sheet with different sections missing
     # WHEN-THEN: we validate it raises a missing section error
     with pytest.raises(SampleSheetMissingSectionHeaderError):
-        check_section_headers("mock.csv", data)
+        check_section_headers(data)
 
 
 ################################################################################
@@ -93,7 +93,7 @@ def test_truncated_file(data):
     # WHEN-THEN: we validate it raises a truncation error
     """If file appears truncated should raise an error."""
     with pytest.raises(SampleSheetTruncatedFileError):
-        check_file_truncation("mock.csv", data)
+        check_file_truncation(data)
 
 
 ################################################################################
@@ -130,7 +130,7 @@ def test_null_row_in_data_section(data):
     # GIVEN: a sample sheet with an empty row
     # WHEN-THEN: we validate it raises a null row error
     with pytest.raises(SampleSheetNullRowError):
-        check_null_rows("mock.csv", data)
+        check_null_rows(data)
 
 
 ################################################################################
@@ -166,7 +166,7 @@ def test_null_row_in_another_section(data):
     """Empty rows in the other sections should do nothing."""
     # GIVEN: a sample sheet with an empty row in the header of manifests section
     # WHEN-THEN: we validate it and it raises no errors
-    check_null_rows("mock.csv", data)
+    check_null_rows(data)
 
 
 ################################################################################
@@ -209,7 +209,7 @@ def test_check_required_columns(missing_data_req_column):
     # GIVEN: a sample sheet with a missing required column
     # WHEN-THEN: we validate it and it raises a missing column error
     with pytest.raises(SampleSheetMissingRequiredColumnsError):
-        check_required_columns("mock.csv", SampleSheet(missing_data_req_column))
+        check_required_columns(SampleSheet(missing_data_req_column))
 
 
 ################################################################################
@@ -253,4 +253,4 @@ def test_null_columns(missing_data_values):
     # GIVEN: a sample sheet with a missing data in a required column
     # WHEN-THEN: we validate it and it raises a missing value error
     with pytest.raises(SampleSheetMissingValueRequiredColumnsError):
-        check_missing_values_required_columns("mock.csv", SampleSheet(missing_data_values))
+        check_missing_values_required_columns(SampleSheet(missing_data_values))


### PR DESCRIPTION
This is a complete re-working of `cgr pre-flight`.

- Automatically Sample_IDs for user files that fail a check
  - Adds config section `Sample_ID_to_remove`
  - Adds Sample_ID to this section if their GTC or IDATs fail
  - Updates `num_samples` and `num_snps`
  - Updates `ConfigMgr` to drop samples in the `Sample_ID_to_remove` so they will be ignored in the workflow.
- Adds multiprocessing for user files
  - User can set the number of threads from the command line
  - Validates samples in parallel to speed up for large number of samples
-  Adds improved messaging and error handling
  - Switches from `ConfigMgr` to `Config`/`SampleSheet` to control the order that checks occur and better handle issues with the config file or sample sheet.
  - Adds explicit check of the config file
  - Gracefully exists if there are any issues with the config file or sample sheet
  - Cleans up messaging for all file types 


Closes #13, closes #14, closes #71, closes #72