### PR TITLE
Fix ancestry plot when missing case or control

### DIFF
--- a/src/cgr_gwas_qc/workflow/scripts/plot_ancestry.py
+++ b/src/cgr_gwas_qc/workflow/scripts/plot_ancestry.py
@@ -44,19 +44,21 @@ def plot(sample: pd.DataFrame, outfile: Optional[os.PathLike] = None):
 
     # Plot cases and controls separately
     case = sample.query("case_control == 'Case'")
-    case_color = CASE_CONTROL_COLORS[0]
-    tax.scatter(
-        case[["EUR", "AFR", "ASN"]].values, color=case_color, label="Case", **style_defaults
-    )
+    if case.shape[0] > 0:
+        case_color = CASE_CONTROL_COLORS[0]
+        tax.scatter(
+            case[["EUR", "AFR", "ASN"]].values, color=case_color, label="Case", **style_defaults
+        )
 
     control = sample.query("case_control == 'Control'")
-    control_color = CASE_CONTROL_COLORS[1]
-    tax.scatter(
-        control[["EUR", "AFR", "ASN"]].values,
-        color=control_color,
-        label="Control",
-        **style_defaults
-    )
+    if control.shape[0] > 0:
+        control_color = CASE_CONTROL_COLORS[1]
+        tax.scatter(
+            control[["EUR", "AFR", "ASN"]].values,
+            color=control_color,
+            label="Control",
+            **style_defaults
+        )
 
     # Add plot elements
     multiple = 0.1  # Our scale is 0 to 1 and we want 0.1 increments

--- a/tests/workflow/scripts/test_plot_ancestry.py
+++ b/tests/workflow/scripts/test_plot_ancestry.py
@@ -1,0 +1,23 @@
+from cgr_gwas_qc.workflow.scripts import plot_ancestry
+
+
+def test_plot_ancestry(sample_qc_csv, tmp_path):
+    outfile = tmp_path / "ancestry.png"
+    plot_ancestry.main(sample_qc_csv, outfile)
+    assert outfile.exists()
+
+
+def test_plot_ancestry_no_case(sample_qc_df, tmp_path):
+    sample_qc_csv = tmp_path / "qc.csv"
+    outfile = tmp_path / "ancestry.png"
+    sample_qc_df.query("case_control != 'Case'").to_csv(sample_qc_csv, index=False)
+    plot_ancestry.main(sample_qc_csv, outfile)
+    assert outfile.exists()
+
+
+def test_plot_ancestry_no_controls(sample_qc_df, tmp_path):
+    sample_qc_csv = tmp_path / "qc.csv"
+    outfile = tmp_path / "ancestry.png"
+    sample_qc_df.query("case_control != 'Control'").to_csv(sample_qc_csv, index=False)
+    plot_ancestry.main(sample_qc_csv, outfile)
+    assert outfile.exists()


### PR DESCRIPTION
I was plotting Cases and Controls separately with a tri-axis. This throws an error if there are no cases or controls. Adds if statement to only plot if there is data.

Closes #133