### PR TITLE
Add table summarizing sex verification

### DIFF
--- a/src/cgr_gwas_qc/reporting/templates/qc_report.md.j2
+++ b/src/cgr_gwas_qc/reporting/templates/qc_report.md.j2
@@ -107,6 +107,10 @@ NOTE: Samples that fail the sex concordance check may be eligible for recovery e
 
 **Figure 2** F coefficient distribution (chromosome X) by reported sex.
 
+{% if subject_qc.sex_verification.table %}
+{{ subject_qc.sex_verification.table }}
+{% endif %}
+
 ## Unexpected Replicates
 
 Next, we checked if two study subjects were taken from the same individual (i.e., biological replicates or tumor/normal sampling).

--- a/src/cgr_gwas_qc/workflow/scripts/qc_report.py
+++ b/src/cgr_gwas_qc/workflow/scripts/qc_report.py
@@ -68,6 +68,7 @@ def main(
             ancestry_png,
         ),
         "subject_qc": SubjectQC.construct(
+            ss,
             subject_qc,
             unexpected_replicates,
             chrx_inbreeding_png,

--- a/tests/reporting/test_subject_qc.py
+++ b/tests/reporting/test_subject_qc.py
@@ -1,4 +1,5 @@
 import shutil
+from io import StringIO
 from pathlib import Path
 from typing import Tuple
 
@@ -29,12 +30,21 @@ def test_UnExpectedReplicates(subject_qc_df, unexpected_replicates_df):
 
 
 @pytest.mark.real_data
-def test_SexVerification(subject_qc_df):
+def test_SexVerification(real_cfg, subject_qc_df):
     from cgr_gwas_qc.reporting.subject_qc import SexVerification
 
-    sv = SexVerification.construct(subject_qc_df, Path("test.png"))
+    sv = SexVerification.construct(real_cfg.ss, subject_qc_df, Path("test.png"))
 
     assert 3 == sv.num_sex_discordant
+
+    # The markdown table should have the same number of rows
+    obs_df = (
+        pd.read_csv(StringIO(sv.table), sep="|", skipinitialspace=True)
+        .dropna(axis=1, how="all")
+        .iloc[1:, :]
+    )
+    obs_df.columns = obs_df.columns.str.strip()
+    assert 3 == obs_df.shape[0]
 
 
 @pytest.mark.real_data


### PR DESCRIPTION
Adds a small summary table in the sex verification section in the QC report. This table should be filled in later if more sex verification checks are performed.

Closes #142