### PR TITLE
Match legacy contamination logic

### DIFF
--- a/src/cgr_gwas_qc/workflow/scripts/agg_contamination.py
+++ b/src/cgr_gwas_qc/workflow/scripts/agg_contamination.py
@@ -58,7 +58,7 @@ def build(contamination_file: Path, median_intensity_file: Path, imiss_file: Pat
 
 def _mask_low_intensity(df: pd.DataFrame, threshold: float) -> pd.DataFrame:
     """Set %Mix to NA if below intensity threshold or not in imiss file"""
-    mask = (df.median_intensity < threshold) | df.F_MISS.isna()
+    mask = (df.median_intensity < threshold) & df.F_MISS.isna()
     df.loc[mask, "%Mix"] = pd.NA
     return df
 

--- a/tests/workflow/scripts/test_agg_contamination.py
+++ b/tests/workflow/scripts/test_agg_contamination.py
@@ -1,6 +1,9 @@
 from textwrap import dedent
 
+import numpy as np
+import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 from cgr_gwas_qc.workflow.scripts import agg_contamination
 
@@ -16,6 +19,7 @@ def contam_csv(tmp_path):
             SP00002,0.20,-2,0.2
             SP00003,0.01,-2,0.2
             SP00004,0.01,-2,0.2
+            SP00005,0.01,-2,0.2
             """
         )
     )
@@ -34,6 +38,7 @@ def intensity_csv(tmp_path):
             SP00002,test1,7000.0
             SP00003,test1,4000.0
             SP00004,test1,7000.0
+            SP00005,test1,4000.0
             """
         )
     )
@@ -57,25 +62,92 @@ def imiss_file(tmp_path):
 
 
 @pytest.fixture
-def agg_df(contam_csv, intensity_csv, imiss_file):
-    return agg_contamination.build(contam_csv, intensity_csv, imiss_file)
+def contam_df():
+    return pd.DataFrame(
+        [
+            #   0        1     2   3      4        5     6    7      8       9     10
+            ("SP00001", 0.01, -2, 0.2, "test1", 7000.0, "Y", 7000, 700000, 0.01, False),
+            ("SP00002", 0.20, -2, 0.2, "test1", 7000.0, "Y", 7000, 700000, 0.01, True),
+            ("SP00003", 0.01, -2, 0.2, "test1", 4000.0, "Y", 7000, 700000, 0.01, False),
+            ("SP00004", 0.01, -2, 0.2, "test1", 7000.0, np.nan, np.nan, np.nan, np.nan, False),
+            ("SP00005", 0.01, -2, 0.2, "test1", 4000.0, np.nan, np.nan, np.nan, np.nan, False),
+        ],
+        columns=(
+            "Sample_ID",  # 0
+            "%Mix",  # 1
+            "LLK",  # 2
+            "LKK0",  # 3
+            "Chip_ID",  # 4
+            "median_intensity",  # 5
+            "MISS_PHENO",  # 6
+            "N_MISS",  # 7
+            "N_GENO",  # 8
+            "F_MISS",  # 9
+            "is_contaminated",  # 10
+        ),
+    )
 
 
-def test_mask_low_intensity(agg_df, software_params):
+def test_agg_df(contam_csv, intensity_csv, imiss_file, contam_df):
+    expected = contam_df.drop("is_contaminated", axis=1)
+    obs = agg_contamination.build(contam_csv, intensity_csv, imiss_file)
+    assert_frame_equal(expected, obs)
+
+
+def test_mask_low_intensity(contam_df, software_params):
     """Check that two NAs are added.
 
     SP00003 should be NA b/c of low intensity.
     SP00004 should be NA b/c of missing in imiss file.
     """
-    obs_df = agg_contamination._mask_low_intensity(agg_df, software_params.intensity_threshold)
-    assert obs_df["%Mix"].isna().sum() == 2
+    # GIVEN: contamination table
+    obs_df = contam_df.drop("is_contaminated", axis=1)
+    expected_df = contam_df.drop("is_contaminated", axis=1)
+
+    # WHEN: I mask low intensity values
+    threshold = software_params.intensity_threshold
+    agg_contamination._mask_low_intensity(obs_df, threshold)
+
+    # THEN: %MIX should be NA at low intensity
+    expected_df.loc[4, "%Mix"] = pd.NA  # SP00005 b/c < threshold and missing F_MISS
+    assert_frame_equal(expected_df, obs_df)
 
 
-def test_flag_contaminated(agg_df, software_params):
+def test_flag_contaminated(contam_df, software_params):
     """Check that one sample is contaminated.
 
     SP00002 should be contaminated.
     """
-    obs_df = agg_contamination._flag_contaminated(agg_df, software_params.contam_threshold)
-    assert 1 == obs_df["is_contaminated"].sum()
-    assert "SP00002" == obs_df[obs_df.is_contaminated].squeeze().Sample_ID
+    obs_df = (
+        contam_df.drop("is_contaminated", axis=1)
+        .pipe(agg_contamination._mask_low_intensity, software_params.intensity_threshold)
+        .pipe(agg_contamination._flag_contaminated, software_params.contam_threshold)
+    )
+
+    assert_series_equal(contam_df.is_contaminated, obs_df.is_contaminated)
+
+
+@pytest.mark.real_data
+@pytest.mark.regression
+def test_legacy_masking(real_data_cache, software_params, tmp_path):
+    # GIVEN: legacy and dev workflow outputs
+    legacy = pd.read_csv(
+        real_data_cache / "legacy_outputs/all_contam/contam.csv",
+        index_col=0,
+        usecols=["ID", "%Mix"],
+    ).squeeze()
+
+    # WHEN: Run the agg script
+    outfile = tmp_path / "test.csv"
+    agg_contamination.main(
+        real_data_cache / "dev_outputs/sample_level/contamination/verifyIDintensity.csv",
+        real_data_cache / "dev_outputs/sample_level/contamination/median_idat_intensity.csv",
+        real_data_cache / "dev_outputs/sample_level/call_rate_2/samples.imiss",
+        software_params.intensity_threshold,
+        software_params.contam_threshold,
+        outfile,
+    )
+    dev = pd.read_csv(outfile, index_col=0, usecols=["Sample_ID", "%Mix"]).squeeze()
+
+    # THEN: legacy and dev masking should be identical
+    assert_series_equal(legacy.isna(), dev.isna(), check_names=False)


### PR DESCRIPTION
When masking contamination rate due to idat intensity and call rate, I had flipped the logic from `and` to `or`. This changes the logic to match the legacy workflow and adds a number of tests to verify this.

Closes #171