### PR TITLE
fix(cluster_profiles): add another fail state for cgems cluster profile

### DIFF
--- a/src/cgr_gwas_qc/cluster_profiles/cgems/cgems_status.py
+++ b/src/cgr_gwas_qc/cluster_profiles/cgems/cgems_status.py
@@ -37,11 +37,11 @@ def check_queue(job_id: int) -> Optional[str]:
         logger.info(f"{job_id} no in queue")
         return None
 
-    if job_status == "Eqw":  # Delete jobs in Eqw b/c they just sit there
-        qdel(job_id)
+    if job_status == "E":
         return "failed"
 
-    if job_status == "E":
+    if job_status.startswith("E") or job_status.startswith("d"):  # Error or Deletion state
+        qdel(job_id)
         return "failed"
 
     return "running"


### PR DESCRIPTION
If a node dies and a job gets delete it is often put into `dr` status. The job
is dead and just sitting there so I want to signal that this is a failure and
keep going with the workflow.

Closes #192