### PR TITLE
Fixes #240: convert alt case/control labels to Unknown

### DIFF
--- a/src/cgr_gwas_qc/models/config/workflow_params.py
+++ b/src/cgr_gwas_qc/models/config/workflow_params.py
@@ -15,7 +15,7 @@ class WorkflowParams(BaseModel):
             remove_rep_discordant: true
             minimum_pop_subjects: 50
             control_hwp_threshold: 50
-            lims_upload: false
+            lims_upload: true
             case_control_gwas: false
     """
 

--- a/tests/models/test_config_data_model.py
+++ b/tests/models/test_config_data_model.py
@@ -154,7 +154,7 @@ def test_workflow_params_defaults():
     assert workflow_params.remove_rep_discordant is True
     assert workflow_params.minimum_pop_subjects == 50
     assert workflow_params.control_hwp_threshold == 50
-    assert workflow_params.lims_upload is False
+    assert workflow_params.lims_upload is True
 
 
 @pytest.mark.parametrize("value", [-0.01, 0, 1.01])

--- a/tests/workflow/scripts/test_sample_concordance.py
+++ b/tests/workflow/scripts/test_sample_concordance.py
@@ -111,7 +111,7 @@ def test_add_discordant_replicate_missing_pair(fake_cfg, concordance):
         (False, True, pd.NA, pd.NA, "ID"),  # KING concordant
         (True, True, pd.NA, "UN", pd.NA),  # GRAF discordant
         (True, True, pd.NA, pd.NA, "UN"),  # KING discordant
-        (False, True, pd.NA, pd.NA, pd.NA),  # All missing so don't call
+        (True, True, pd.NA, pd.NA, pd.NA),  # All missing so don't call
     ],
 )
 def test_add_discordant_logic(expected_result, is_rep, plink, graf, king):

--- a/tests/workflow/scripts/test_sample_concordance.py
+++ b/tests/workflow/scripts/test_sample_concordance.py
@@ -111,7 +111,7 @@ def test_add_discordant_replicate_missing_pair(fake_cfg, concordance):
         (False, True, pd.NA, pd.NA, "ID"),  # KING concordant
         (True, True, pd.NA, "UN", pd.NA),  # GRAF discordant
         (True, True, pd.NA, pd.NA, "UN"),  # KING discordant
-        (True, True, pd.NA, pd.NA, pd.NA),  # All missing so don't call
+        (True, True, pd.NA, pd.NA, pd.NA),  # All missing: flag as discordant replicate
     ],
 )
 def test_add_discordant_logic(expected_result, is_rep, plink, graf, king):


### PR DESCRIPTION
Convert all samples' case/control status to "Unknown" when their label is not in [Case, Control, QC, Unknown].