### PR TITLE
Refactor to capture exit_status for successful runs

### DIFF
--- a/src/cgr_gwas_qc/cluster_profiles/snakemake.sh
+++ b/src/cgr_gwas_qc/cluster_profiles/snakemake.sh
@@ -191,7 +191,8 @@ run_workflow() {
   {{ python_executable }} -m cgr_gwas_qc snakemake \
     --local-cores {{ local_tasks }} \
     --profile {{ profile }} \
-    {{ added_options }} || exit_status=$?  # Don't exit on failure, see why we exited
+    {{ added_options }}
+  exit_status=$?
 
   if (( exit_status != 0 )) && log_says_locked; then
     exit 42


### PR DESCRIPTION
The submission script would incorrectly report a workflow error even when it finished successfully. This was due to the inline `exit_status` assignment logic, which only captured unsuccessful runs, leaving the `exit_status` variable unassigned for successful runs. This resulted in an "unbound variable" error message in the logs. To address this issue, we moved the `exit_status` assignment to the next line (not inline) to ensure that the variable is properly assigned even for successful runs (exit code 0) of the snakemake command. This change resolves the issue and ensures accurate reporting of workflow status.

Fixes #262