### PR TITLE
Fix documentation auto implementation of version release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ exclude_patterns = [
 rst_prolog = f"""
 .. |pkgurl| replace:: https://github.com/NCI-CGR/GwasQcPipeline/releases/download/{__version__}/{pkg}
 .. |cgr| replace:: *CGR GwasQcPipeline*
+.. |pkg_version| replace:: {__version__}
 """
 
 rst_epilog = ".. include:: /common_urls.rst"

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -45,13 +45,15 @@ To update the latest version of ``GwasQcPipeline``:
 Installing on ccad2
 -------------------------
 
-- Install miniconda and then create a GwasQcPipeline production environment
-.. code-block::
+Install miniconda and then create a GwasQcPipeline production environment:
 
-   $ mkdir /scratch/myfolder/GwasQcPipeline_v1.2
-   $ cd /scratch/myfolder/GwasQcPipeline_v1.2
+.. code-block::
+   :substitutions:
+
+   $ mkdir /scratch/myfolder/GwasQcPipeline_|pkg_version|
+   $ cd /scratch/myfolder/GwasQcPipeline_|pkg_version|
    $ wget https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh
-   $ bash Miniconda3-py39_4.12.0-Linux-x86_64.sh -p /scratch/myfolder/GwasQcPipeline_v1.2/conda -b
+   $ bash Miniconda3-py39_4.12.0-Linux-x86_64.sh -p /scratch/myfolder/GwasQcPipeline_|pkg_version|/conda -b
    $ source conda/bin/activate base
    (base) $ conda update -n base -c defaults conda
    (base) $ conda install -n base -c conda-forge mamba
@@ -59,12 +61,15 @@ Installing on ccad2
    (base) $ conda deactivate
 
 Next install the latest version of the GwasQcPipeline environment:
+
 .. code-block::
-   $ source /scratch/myfolder/GwasQcPipeline_v1.2/conda/bin/activate GwasQcPipeline 
-   (GwasQcPipeline) $ pip install https://github.com/NCI-CGR/GwasQcPipeline/releases/download/v1.2.0/cgr_gwas_qc-1.2.0-py3-none-any.whl
+   :substitutions:
+
+   $ source /scratch/myfolder/GwasQcPipeline_|pkg_version|/conda/bin/activate GwasQcPipeline
+   (GwasQcPipeline) $ pip install |pkgurl|
    (GwasQcPipeline) $ cgr --help
    (GwasQcPipeline) $ cgr version
-   v1.2.0
+   |pkg_version|
 
 Installing on NIH Biowulf
 -------------------------
@@ -76,6 +81,7 @@ description is provided on the `Biowulf python env website`_.
 
 
 .. code-block::
+   :substitutions:
 
    $ wget https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-x86_64.sh
 
@@ -91,9 +97,10 @@ description is provided on the `Biowulf python env website`_.
 Next install the latest version of the GwasQcPipeline environment:
 
 .. code-block::
+   :substitutions:
 
    $ source /<location of miniconda installation>/conda/bin/activate GwasQcPipeline
-   $ pip install --force-reinstall  https://github.com/NCI-CGR/GwasQcPipeline/releases/download/v1.2.0/cgr_gwas_qc-1.2.0-py3-none-any.whl
+   $ pip install --force-reinstall |pkgurl|
    $ cgr --help
    $ cgr version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cgr_gwas_qc"
-version = "1.3.0"
+version = "1.4.0"
 description = "The CGR GWAS QC Pipeline"
 authors = [
     "Justin Fear <justin.fear@nih.gov>",


### PR DESCRIPTION
- Added |pkg_version| variable to substitute in code blocks
- ccad2 installation instructions weren't automated. Fixed now
- Updated pyproject.toml to release 1.4.0