### PR TITLE
bugfix: error when setting `case_control_gwas=true`

### DIFF
--- a/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
@@ -48,6 +48,7 @@ targets = [
     "subject_level/subjects.fam",
     "subject_level/concordance.csv",
     "subject_level/population_qc.csv",
+    "subject_level/gwas.txt",
     "subject_level/.population_plots.done",
     "subject_level/.control_plots.done",
     "delivery/gwas.assoc",
@@ -536,6 +537,7 @@ rule agg_population_qc_tables:
         population_qc_tables=_population_qc_tables,
     output:
         "subject_level/population_qc.csv",
+        "subject_level/gwas.txt",
     script:
         "../scripts/agg_population_qc_tables.py"
 


### PR DESCRIPTION
**Issue:** When setting `case_control_gwas = true` in the config file, an error
       occurred due to a missing `subject_level/gwas.txt` file.

**Cause:** The `gwas` rule requires `subject_level/gwas.txt` as input. However,
       the script used by the `agg_population_qc_tables` rule generates
       this file, but it wasn't listed as an output.

**Solution:** This commit explicitly adds `gwas.txt` as an output of the
          `agg_population_qc_tables` rule, ensuring the `gwas` rule correctly
          waits for its dependency before execution.
          
<br><br>
          
**Fixes** #280 