### PR TITLE
bugfix: retrieve additional missing data from `QC_Report.xlsx` 

### DIFF
--- a/src/cgr_gwas_qc/workflow/scripts/qc_report_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/qc_report_table.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import List
 
 import pandas as pd
 import typer
@@ -28,7 +29,6 @@ def main(
     graf: Path,
     outfile: Path,
 ):
-
     with pd.ExcelWriter(outfile) as writer:
         _sample_qc(sample_sheet_csv, sample_qc_csv).to_excel(
             writer, sheet_name="SAMPLE_QC", index=False
@@ -83,14 +83,30 @@ _SAMPLE_QC_COLUMNS = [
 ]
 
 
+_PASS_FAIL_QC_COLUMNS: List[str] = [
+    "is_call_rate_filtered",
+    "is_contaminated",
+    "Expected Replicate Discordance",
+    "Unexpected Replicate",
+    "is_sex_discordant",
+]
+
+
+def _count_issues(sample_qc_csv: PathLike, qc_columns: List[str]) -> pd.DataFrame:
+    df = sample_qc_table.read(sample_qc_csv)
+    df["Count_of_QC_Issue"] = df[qc_columns].sum(axis=1)
+    return df
+
+
 def _sample_qc(sample_sheet_csv: PathLike, sample_qc_csv: PathLike) -> pd.DataFrame:
     ss = sample_sheet.read(sample_sheet_csv, remove_exclusions=False).rename(
         REPORT_NAME_MAPPER, axis=1
     )
     _additional_columns = [x for x in ss.columns if x not in _SAMPLE_QC_COLUMNS]
+
+    df = _count_issues(sample_qc_csv, _PASS_FAIL_QC_COLUMNS)
     return (
-        sample_qc_table.read(sample_qc_csv)
-        .rename(REPORT_NAME_MAPPER, axis=1)
+        df.rename(REPORT_NAME_MAPPER, axis=1)
         .merge(ss, on="Sample_ID", suffixes=["", "_DROP"], how="outer")
         .filter(regex="^(?!.*_DROP)")
         .reindex(_SAMPLE_QC_COLUMNS + _additional_columns, axis=1)

--- a/src/cgr_gwas_qc/workflow/scripts/qc_report_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/qc_report_table.py
@@ -69,7 +69,6 @@ _SAMPLE_QC_COLUMNS = [
     "Contaminated",
     "Contamination_Rate",
     "IdatIntensity",
-    "Expected Replicate",
     "Expected Replicate Discordance",
     "Unexpected Replicate",
     "Sex Discordant",

--- a/src/cgr_gwas_qc/workflow/scripts/qc_report_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/qc_report_table.py
@@ -95,6 +95,7 @@ _PASS_FAIL_QC_COLUMNS: List[str] = [
 def _count_issues(sample_qc_csv: PathLike, qc_columns: List[str]) -> pd.DataFrame:
     df = sample_qc_table.read(sample_qc_csv)
     df["Count_of_QC_Issue"] = df[qc_columns].sum(axis=1)
+    df["Sample Pass QC"] = df["Count_of_QC_Issue"] == 0  # TRUE iif all pass_fail columns are true
     return df
 
 

--- a/src/cgr_gwas_qc/workflow/scripts/qc_report_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/qc_report_table.py
@@ -56,7 +56,6 @@ _SAMPLE_QC_COLUMNS = [
     "Number Samples Per Subject",
     "Replicate IDs",
     "Sample Excluded from QC",
-    "IdatsInProjectDir",
     "Sample Used in Subject Analysis",
     "Subject Removed",
     # QC Results


### PR DESCRIPTION
This PR fixes missing data in the SAMPLE_QC tab of the `QC_Report.xlsx`. In particular, it implements the logic to capture data for the "Count_of_QC_Issue" and "Sample Pass QC" columns. It also removes redundant columns "Expected Replicate" and  "IdatsInProjectDir" from the tab.

---

Fixes #306 