### PR TITLE
fix: Handle removal of discordant expected replicates (issue #210)

### DIFF
--- a/src/cgr_gwas_qc/workflow/conda/illuminaio.yml
+++ b/src/cgr_gwas_qc/workflow/conda/illuminaio.yml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bioconductor-illuminaio=0.20.0
+  - bioconductor-illuminaio=0.44.0

--- a/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
@@ -192,20 +192,18 @@ def main(
     )
 
     add_qc_columns(
-        sample_qc, remove_contam, remove_rep_discordant,
+        sample_qc,
+        remove_contam,
+        remove_rep_discordant,
     )
-    sample_qc["is_unexpected_replicate"] = (
-        sample_qc["is_unexpected_replicate"].replace("", False).fillna(False)
-    )
-    sample_qc["is_discordant_replicate"] = (
-        sample_qc["is_discordant_replicate"].replace("", False).fillna(False)
-    )
+
     sample_qc = sample_qc.rename(
         columns={
             "is_unexpected_replicate": "Unexpected Replicate",
             "is_discordant_replicate": "Expected Replicate Discordance",
         }
     )
+
     save(sample_qc, outfile)
 
 
@@ -396,6 +394,8 @@ def _read_concordance(filename: Path, Sample_IDs: pd.Index) -> pd.DataFrame:
         .max()  # Flag a sample as True if it is True for any comparison.
         .astype("boolean")
         .reindex(Sample_IDs)
+        .replace("", False)
+        .fillna(False)
     )
 
 
@@ -413,7 +413,8 @@ def _read_contam(file_name: Optional[Path], Sample_IDs: pd.Index) -> pd.DataFram
 
     if file_name is None:
         return pd.DataFrame(
-            index=Sample_IDs, columns=["Contamination_Rate", "is_contaminated"],
+            index=Sample_IDs,
+            columns=["Contamination_Rate", "is_contaminated"],
         ).astype({"Contamination_Rate": "float", "is_contaminated": "boolean"})
 
     return (
@@ -456,12 +457,16 @@ def _read_intensity(file_name: Optional[Path], Sample_IDs: pd.Index) -> pd.Serie
 
 
 def add_qc_columns(
-    sample_qc: pd.DataFrame, remove_contam: bool, remove_rep_discordant: bool,
+    sample_qc: pd.DataFrame,
+    remove_contam: bool,
+    remove_rep_discordant: bool,
 ) -> pd.DataFrame:
     add_call_rate_flags(sample_qc)
     _add_identifiler(sample_qc)
     _add_analytic_exclusion(
-        sample_qc, remove_contam, remove_rep_discordant,
+        sample_qc,
+        remove_contam,
+        remove_rep_discordant,
     )
     _add_subject_representative(sample_qc)
     _add_subject_dropped_from_study(sample_qc)
@@ -507,7 +512,9 @@ def _get_reason(sample_qc: pd.DataFrame, flags: Mapping[str, str]):
 
 
 def _add_analytic_exclusion(
-    sample_qc: pd.DataFrame, remove_contam: bool, remove_rep_discordant: bool,
+    sample_qc: pd.DataFrame,
+    remove_contam: bool,
+    remove_rep_discordant: bool,
 ) -> pd.DataFrame:
     """Adds a flag to remove samples based on provided conditions.
 

--- a/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
@@ -192,9 +192,7 @@ def main(
     )
 
     add_qc_columns(
-        sample_qc,
-        remove_contam,
-        remove_rep_discordant,
+        sample_qc, remove_contam, remove_rep_discordant,
     )
 
     sample_qc = sample_qc.rename(
@@ -413,8 +411,7 @@ def _read_contam(file_name: Optional[Path], Sample_IDs: pd.Index) -> pd.DataFram
 
     if file_name is None:
         return pd.DataFrame(
-            index=Sample_IDs,
-            columns=["Contamination_Rate", "is_contaminated"],
+            index=Sample_IDs, columns=["Contamination_Rate", "is_contaminated"],
         ).astype({"Contamination_Rate": "float", "is_contaminated": "boolean"})
 
     return (
@@ -457,16 +454,12 @@ def _read_intensity(file_name: Optional[Path], Sample_IDs: pd.Index) -> pd.Serie
 
 
 def add_qc_columns(
-    sample_qc: pd.DataFrame,
-    remove_contam: bool,
-    remove_rep_discordant: bool,
+    sample_qc: pd.DataFrame, remove_contam: bool, remove_rep_discordant: bool,
 ) -> pd.DataFrame:
     add_call_rate_flags(sample_qc)
     _add_identifiler(sample_qc)
     _add_analytic_exclusion(
-        sample_qc,
-        remove_contam,
-        remove_rep_discordant,
+        sample_qc, remove_contam, remove_rep_discordant,
     )
     _add_subject_representative(sample_qc)
     _add_subject_dropped_from_study(sample_qc)
@@ -512,9 +505,7 @@ def _get_reason(sample_qc: pd.DataFrame, flags: Mapping[str, str]):
 
 
 def _add_analytic_exclusion(
-    sample_qc: pd.DataFrame,
-    remove_contam: bool,
-    remove_rep_discordant: bool,
+    sample_qc: pd.DataFrame, remove_contam: bool, remove_rep_discordant: bool,
 ) -> pd.DataFrame:
     """Adds a flag to remove samples based on provided conditions.
 
@@ -534,7 +525,7 @@ def _add_analytic_exclusion(
         exclusion_criteria["is_contaminated"] = "Contamination"
 
     if remove_rep_discordant:
-        exclusion_criteria["Expected Replicate Discordance"] = "Replicate Discordance"
+        exclusion_criteria["is_discordant_replicate"] = "Replicate Discordance"
 
     sample_qc["analytic_exclusion"] = sample_qc.reindex(exclusion_criteria.keys(), axis=1).any(
         axis=1

--- a/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
@@ -88,13 +88,15 @@ if cfg.config.user_files.gtc_pattern:
             cfg.conda("bcftools-gtc2vcf-plugin")
         shell:
             "bcftools +gtc2vcf --gtcs {input.gtcs} --bpm {input.bpm} --fasta-ref {input.reference_fasta} --output {output.vcf} --use-gtc-sample-names"
+
     rule filter_missing_allele_snps:
         input:
             vcf=rules.gtc_to_vcf.output.vcf,
         output:
             vcf=temp("sample_level/samples_filtered.vcf"),
         shell:
-            "grep -vP '\t\.\t\.\t\.' {input.vcf} > {output.vcf}" 
+            "grep -vP '\t\.\t\.\t\.' {input.vcf} > {output.vcf}"
+
     rule vcf_to_bed:
         input:
             vcf=rules.filter_missing_allele_snps.output.vcf,

--- a/tests/workflow/scripts/test_sample_qc_table.py
+++ b/tests/workflow/scripts/test_sample_qc_table.py
@@ -254,7 +254,7 @@ def fake_sample_qc() -> pd.DataFrame:
         "is_cr1_filtered",
         "is_cr2_filtered",
         "is_contaminated",
-        "Expected Replicate Discordance",
+        "is_discordant_replicate",
     ]
     data = [
         ("SP00001", "SB00001", False, False, 0.99, False, False, False, False),


### PR DESCRIPTION
This PR addresses two issues:

1. Fixes handling of discordant expected replicates (issue #210):
- Previously, the machinery for removing discordant expected replicates was implemented but not functional due to a column name mismatch.
- This PR updates the _add_analytic_exclusion function in ``sample_qc_table.py`` to correctly identify discordant replicates using the actual column name "is_discordant_replicate" from the `concordance summary.csv`.
- With this fix, when the user includes the `remove_rep_discordant=True` flag in `config.yml`, discordant replicates will be excluded from subject analysis as intended.
2. Updates bioconductor-illuminaio package:
- This PR upgrades the bioconductor-illuminaio package to the latest version (v0.44.0) to address dependency issues encountered with the previous version.

<br>

fixes #210 