### PR TITLE
feat: Improve handling of discordant expected replicates (issue #324)

### DIFF
--- a/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
@@ -192,9 +192,7 @@ def main(
     )
 
     add_qc_columns(
-        sample_qc,
-        remove_contam,
-        remove_rep_discordant,
+        sample_qc, remove_contam, remove_rep_discordant,
     )
 
     sample_qc = sample_qc.rename(
@@ -414,8 +412,7 @@ def _read_contam(file_name: Optional[Path], Sample_IDs: pd.Index) -> pd.DataFram
 
     if file_name is None:
         return pd.DataFrame(
-            index=Sample_IDs,
-            columns=["Contamination_Rate", "is_contaminated"],
+            index=Sample_IDs, columns=["Contamination_Rate", "is_contaminated"],
         ).astype({"Contamination_Rate": "float", "is_contaminated": "boolean"})
 
     return (
@@ -458,16 +455,12 @@ def _read_intensity(file_name: Optional[Path], Sample_IDs: pd.Index) -> pd.Serie
 
 
 def add_qc_columns(
-    sample_qc: pd.DataFrame,
-    remove_contam: bool,
-    remove_rep_discordant: bool,
+    sample_qc: pd.DataFrame, remove_contam: bool, remove_rep_discordant: bool,
 ) -> pd.DataFrame:
     add_call_rate_flags(sample_qc)
     _add_identifiler(sample_qc)
     _add_analytic_exclusion(
-        sample_qc,
-        remove_contam,
-        remove_rep_discordant,
+        sample_qc, remove_contam, remove_rep_discordant,
     )
     _add_subject_representative(sample_qc)
     _add_subject_dropped_from_study(sample_qc)
@@ -512,9 +505,7 @@ def _get_reason(sample_qc: pd.DataFrame, flags: Mapping[str, str]):
     return sample_qc.apply(reason_string, axis=1)
 
 
-def _retain_valid_discordant_replicates(
-    sample_qc: pd.DataFrame,
-) -> pd.DataFrame:
+def _retain_valid_discordant_replicates(sample_qc: pd.DataFrame,) -> pd.DataFrame:
     """Check and update the status of a pair of samples labeled as
        discordant expected replicates.
 
@@ -567,9 +558,7 @@ def _retain_valid_discordant_replicates(
 
 
 def _add_analytic_exclusion(
-    sample_qc: pd.DataFrame,
-    remove_contam: bool,
-    remove_rep_discordant: bool,
+    sample_qc: pd.DataFrame, remove_contam: bool, remove_rep_discordant: bool,
 ) -> pd.DataFrame:
     """Adds a flag to remove samples based on provided conditions.
 

--- a/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
@@ -192,7 +192,9 @@ def main(
     )
 
     add_qc_columns(
-        sample_qc, remove_contam, remove_rep_discordant,
+        sample_qc,
+        remove_contam,
+        remove_rep_discordant,
     )
 
     sample_qc = sample_qc.rename(
@@ -412,7 +414,8 @@ def _read_contam(file_name: Optional[Path], Sample_IDs: pd.Index) -> pd.DataFram
 
     if file_name is None:
         return pd.DataFrame(
-            index=Sample_IDs, columns=["Contamination_Rate", "is_contaminated"],
+            index=Sample_IDs,
+            columns=["Contamination_Rate", "is_contaminated"],
         ).astype({"Contamination_Rate": "float", "is_contaminated": "boolean"})
 
     return (
@@ -455,12 +458,16 @@ def _read_intensity(file_name: Optional[Path], Sample_IDs: pd.Index) -> pd.Serie
 
 
 def add_qc_columns(
-    sample_qc: pd.DataFrame, remove_contam: bool, remove_rep_discordant: bool,
+    sample_qc: pd.DataFrame,
+    remove_contam: bool,
+    remove_rep_discordant: bool,
 ) -> pd.DataFrame:
     add_call_rate_flags(sample_qc)
     _add_identifiler(sample_qc)
     _add_analytic_exclusion(
-        sample_qc, remove_contam, remove_rep_discordant,
+        sample_qc,
+        remove_contam,
+        remove_rep_discordant,
     )
     _add_subject_representative(sample_qc)
     _add_subject_dropped_from_study(sample_qc)
@@ -505,8 +512,64 @@ def _get_reason(sample_qc: pd.DataFrame, flags: Mapping[str, str]):
     return sample_qc.apply(reason_string, axis=1)
 
 
+def _retain_valid_discordant_replicates(
+    sample_qc: pd.DataFrame,
+) -> pd.DataFrame:
+    """Check and update the status of a pair of samples labeled as
+       discordant expected replicates.
+
+    This function verifies if the provided sample pair is labeled as
+    discordant expected replicates.
+    If they are, it checks for contamination or low call rate flags on
+    each sample.
+    If one of the samples is found to be contaminated or has a low call
+    rate, the function retains the non-contaminated and non-low-call-rate
+    sample, updating its status to remove the expected replicate label.
+    """
+
+    # Iterate through each sample in the DataFrame
+    for index, row in sample_qc.iterrows():
+        # Check if the sample is a discordant expected replicate
+        if row["is_discordant_replicate"]:
+            # Get the list of other samples it is discordant with
+            discordant_samples = row["replicate_ids"].split("|")
+
+            # Initialize flags for contamination and call rate issues
+            is_current_sample_contaminated = row["is_contaminated"]
+            is_current_sample_low_call_rate = row["is_cr2_filtered"]
+
+            # Initialize a flag to track if all discordant samples have issues
+            all_other_samples_issue = True
+
+            # Check each discordant sample
+            for sample_id in discordant_samples:
+                if sample_id == row.name:
+                    continue
+                else:
+                    # Get the row for the discordant sample
+                    discordant_row = sample_qc.loc[sample_id]
+                    if not discordant_row.empty:
+                        # Check if the discordant sample is contaminated or has a low call rate
+                        if (
+                            not discordant_row["is_contaminated"]
+                            and not discordant_row["is_cr2_filtered"]
+                        ):
+                            all_other_samples_issue = False
+                            break
+
+            # If the current sample is not contaminated or low call rate
+            if not is_current_sample_contaminated and not is_current_sample_low_call_rate:
+                # If all other samples have issues, update the current sample's status
+                if all_other_samples_issue:
+                    sample_qc.at[index, "is_discordant_replicate"] = False
+
+    return sample_qc
+
+
 def _add_analytic_exclusion(
-    sample_qc: pd.DataFrame, remove_contam: bool, remove_rep_discordant: bool,
+    sample_qc: pd.DataFrame,
+    remove_contam: bool,
+    remove_rep_discordant: bool,
 ) -> pd.DataFrame:
     """Adds a flag to remove samples based on provided conditions.
 
@@ -521,6 +584,8 @@ def _add_analytic_exclusion(
         "is_cr1_filtered": "Call Rate 1 Filtered",
         "is_cr2_filtered": "Call Rate 2 Filtered",
     }
+
+    _retain_valid_discordant_replicates(sample_qc)
 
     if remove_contam:
         exclusion_criteria["is_contaminated"] = "Contamination"

--- a/tests/workflow/scripts/test_sample_qc_table.py
+++ b/tests/workflow/scripts/test_sample_qc_table.py
@@ -248,6 +248,7 @@ def fake_sample_qc() -> pd.DataFrame:
     columns = [
         "Sample_ID",
         "Group_By_Subject_ID",
+        "replicate_ids",
         "is_sample_exclusion",
         "is_internal_control",
         "Call_Rate_2",
@@ -257,29 +258,65 @@ def fake_sample_qc() -> pd.DataFrame:
         "is_discordant_replicate",
     ]
     data = [
-        ("SP00001", "SB00001", False, False, 0.99, False, False, False, False),
-        ("SP00002", "SB00002", False, False, 0.82, False, True, False, False),
-        ("SP00003", "SB00003", False, False, 0.99, False, False, True, True),
-        ("SP00004", "SB00003", False, False, 0.99, False, False, False, True),
-        ("SP00005", "SB00004", False, False, 0.99, False, False, False, True),
-        ("SP00006", "SB00004", False, False, 0.99, False, False, False, True),
-        ("SP00007", "SB00005", False, False, 0.99, False, False, False, False),
-        ("SP00008", "SB00006", False, False, 0.99, False, False, False, False),
-        ("SP00009", "SB00007", False, False, 0.99, False, False, False, False),
-        ("SP00010", "SB00008", False, False, 0.99, False, False, False, False),
-        ("SP00011", "SB00008", False, False, 0.94, False, False, False, False),
-        ("SP00012", "SB00009", False, False, 0.99, False, False, False, False),
-        ("SP00013", "SB00009", False, False, 0.98, False, False, False, False),
-        ("SP00014", "SB00009", False, False, 0.97, False, False, False, False),
+        ("SP00001", "SB00001", "", False, False, 0.99, False, False, False, False),
+        ("SP00002", "SB00002", "", False, False, 0.82, False, True, False, False),
+        ("SP00003", "SB00003", "SP00003|SP00004", False, False, 0.99, False, False, True, True),
+        ("SP00004", "SB00003", "SP00003|SP00004", False, False, 0.99, False, False, False, True),
+        ("SP00005", "SB00004", "SP00005|SP00006", False, False, 0.99, False, False, False, True),
+        ("SP00006", "SB00004", "SP00005|SP00006", False, False, 0.99, False, False, False, True),
+        ("SP00007", "SB00005", "", False, False, 0.99, False, False, False, False),
+        ("SP00008", "SB00006", "", False, False, 0.99, False, False, False, False),
+        ("SP00009", "SB00007", "", False, False, 0.99, False, False, False, False),
+        ("SP00010", "SB00008", "SP00010|SP00011", False, False, 0.99, False, False, False, False),
+        ("SP00011", "SB00008", "SP00010|SP00011", False, False, 0.94, False, False, False, False),
+        (
+            "SP00012",
+            "SB00009",
+            "SP00012|SP00013|SP00014",
+            False,
+            False,
+            0.99,
+            False,
+            False,
+            False,
+            False,
+        ),
+        (
+            "SP00013",
+            "SB00009",
+            "SP00012|SP00013|SP00014",
+            False,
+            False,
+            0.98,
+            False,
+            False,
+            False,
+            False,
+        ),
+        (
+            "SP00014",
+            "SB00009",
+            "SP00012|SP00013|SP00014",
+            False,
+            False,
+            0.97,
+            False,
+            False,
+            False,
+            False,
+        ),
+        ("SP00015", "SB00010", "SP00015|SP00016", False, False, 0.99, False, True, False, True),
+        ("SP00016", "SB00010", "SP00015|SP00016", False, False, 0.99, False, False, False, True),
     ]
     return pd.DataFrame(data, columns=columns).set_index("Sample_ID")
 
 
 @pytest.mark.parametrize(
     "contam,rep_discordant,num_removed",
-    [(False, False, 1), (True, False, 2), (False, True, 5), (True, True, 5)],  # call rate filtered
+    [(False, False, 2), (True, False, 3), (False, True, 5), (True, True, 5)],  # call rate filtered
 )
 def test_add_analytic_exclusion(fake_sample_qc, contam, rep_discordant, num_removed):
+    pd.set_option("display.max_columns", None)
     sample_qc_table._add_analytic_exclusion(fake_sample_qc, contam, rep_discordant)
     assert num_removed == fake_sample_qc.analytic_exclusion.sum()
 

--- a/tests/workflow/scripts/test_sample_qc_table.py
+++ b/tests/workflow/scripts/test_sample_qc_table.py
@@ -257,6 +257,7 @@ def fake_sample_qc() -> pd.DataFrame:
         "is_contaminated",
         "is_discordant_replicate",
     ]
+
     data = [
         ("SP00001", "SB00001", "", False, False, 0.99, False, False, False, False),
         ("SP00002", "SB00002", "", False, False, 0.82, False, True, False, False),
@@ -321,9 +322,10 @@ def test_add_analytic_exclusion(fake_sample_qc, contam, rep_discordant, num_remo
     assert num_removed == fake_sample_qc.analytic_exclusion.sum()
 
 
+# change these since I updated fake_sample_qc
 @pytest.mark.parametrize(
     "contam,rep_discordant,num_subjects",
-    [(False, False, 8), (True, False, 8), (False, True, 6), (True, True, 6)],
+    [(False, False, 9), (True, False, 9), (False, True, 8), (True, True, 8)],
 )
 def test_add_subject_representative(fake_sample_qc, contam, rep_discordant, num_subjects):
     sample_qc_table._add_analytic_exclusion(fake_sample_qc, contam, rep_discordant)
@@ -333,7 +335,7 @@ def test_add_subject_representative(fake_sample_qc, contam, rep_discordant, num_
 
 @pytest.mark.parametrize(
     "contam,rep_discordant,num_subjects",
-    [(False, False, 1), (True, False, 1), (False, True, 3), (True, True, 3)],
+    [(False, False, 1), (True, False, 1), (False, True, 2), (True, True, 2)],
 )
 def test_add_subject_dropped_from_study(fake_sample_qc, contam, rep_discordant, num_subjects):
     sample_qc_table._add_analytic_exclusion(fake_sample_qc, contam, rep_discordant)


### PR DESCRIPTION
This PR creates a new function `_retain_valid_discordant_replicates` to the script `sample_qc_table.py`, which helps us retain additional subjects in specific cases. Previously, both samples in a discordant expected replicate pair were discarded. Now, if one sample has low call rate or is flagged as contaminated, and the other does not, the high-quality sample is retained. This helps preserve subject data when one sample is compromised.

Additionally, we updated the unit tests in `test_sample_qc_table.py` to cover the new functionality.

Fixes #324 

