### PR TITLE
feat: add `max_time_hr` option for wall-time allocation (issue #334)

### DIFF
--- a/src/cgr_gwas_qc/models/config/software_params.py
+++ b/src/cgr_gwas_qc/models/config/software_params.py
@@ -28,7 +28,6 @@ class SoftwareParams(BaseModel):
             pi_hat_threshold: 0.2
 
             autosomal_het_threshold: 0.1
-
     """
 
     strand: str = Field(

--- a/src/cgr_gwas_qc/models/config/workflow_params.py
+++ b/src/cgr_gwas_qc/models/config/workflow_params.py
@@ -1,4 +1,5 @@
 import time
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -23,6 +24,7 @@ class WorkflowParams(BaseModel):
             lims_upload: true
             lims_output_dir: /DCEG/CGF/Laboratory/LIMS/drop-box-prod/gwas_primaryqc/
             case_control_gwas: false
+            max_time_hr:
             time_start:
     """
 
@@ -87,6 +89,12 @@ class WorkflowParams(BaseModel):
         False,
         description="A plink logistic regression gwas will be performed with case_control phenotype.",
     )
+
+    max_time_hr: Optional[int] = Field(
+        None,
+        description="Allocates the specified number of hours for the execution of the ``sample_concordance_plink`` and ``population_level_ibd`` rules.",
+    )
+
     time_start: str = Field(
         timestr,
         description="Date and time at which the workflow starts. This creates a unique id for the run.",

--- a/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
@@ -2,8 +2,8 @@ from cgr_gwas_qc import load_config
 
 cfg = load_config()
 
-BIG_TIME = {1: 10, 2: 48, 3: 96}
-
+mtime = cfg.config.workflow_params.max_time_hr
+BIG_TIME = dict.fromkeys(range(1, 4), mtime) if mtime else {1: 10, 2: 48, 3: 96}
 
 use_contamination = (
     cfg.config.user_files.idat_pattern

--- a/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
@@ -9,8 +9,8 @@ import math
 
 cfg = load_config()
 
-PLINK_BIG_MEM = {1: 1024 * 4, 2: 1024 * 64, 3: 1024 * 250}
-BIG_TIME = {1: 8, 2: 24, 3: 48}
+mtime = cfg.config.workflow_params.max_time_hr
+BIG_TIME = dict.fromkeys(range(1, 4), mtime) if mtime else {1: 8, 2: 24, 3: 48}
 
 
 localrules:
@@ -280,7 +280,7 @@ use rule genome from plink as population_level_ibd with:
     output:
         "subject_level/{population}/subjects_maf{maf}_ld{ld}_ibd.genome",
     resources:
-        mem_mb=lambda wildcards, attempt: PLINK_BIG_MEM[attempt],
+        mem_mb=lambda wildcards, attempt, input: max((attempt + 1) * input.size_mb, 1024),
         time_hr=lambda wildcards, attempt: BIG_TIME[attempt],
 
 


### PR DESCRIPTION
**What**
This PR introduces a new optional configuration parameter, `max_time_hr`. Users can specify an integer value representing the maximum wall-time allocation in hours. This feature specifically applies to the time-intensive rules `sample_concordance_plink` and `population_level_ibd`.

When `max_time_hr` is set, these two rules will receive their maximum time allocation immediately. If not specified, wall-time allocation will follow the default patterns:
* `{1: 10, 2: 48, 3: 96}` for `sample_concordance_plink`
* `{1: 8, 2: 24, 3: 48}` for `population_level_ibd`


Additionally, we improved the memory allocation for the `population_level_ibd` rule to a data driven approach, similar to commit f672fba.

<br>

**Why**
This update offers two key benefits. First, if a user has a smaller wall-time limit than the default allocations (e.g., 36 hours), jobs may fail if they do not complete on the first attempt. For instance, if the initial allocation for the `sample_concordance_plink` rule is 10 hours and the next attempt is 48 hours, which exceeds the maximum allowed allocation, the job will fail. The new configuration prevents this issue.

Second, for users processing relatively large sample sizes (greater than 100K), the default 10-hour allocation for the `sample_concordance_plink` rule may be insufficient. By specifying a larger time allocation upfront, users can avoid the risk of failure due to wall-time limits, potentially saving time by reducing unnecessary retries.

<br><br>
Fixes #334 