### PR TITLE
test: Add `skipif` decorator to handle CGEMS directory access (issue #336)

### DIFF
--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,12 +1,27 @@
+import os
+
+import pytest
+
 from cgr_gwas_qc.cli.config import CGEMS_QC_DIR, _get_cgems_production_run_dir
 
+# Define the condition for skipping the test
+skip_condition = not os.path.exists(CGEMS_QC_DIR) or not os.access(CGEMS_QC_DIR, os.R_OK)
 
+
+@pytest.mark.skipif(
+    skip_condition,
+    reason=f"Skipping test because {CGEMS_QC_DIR} does not exist or is not accessible.",
+)
 def test_get_cgems_production_run_dir(monkeypatch):
     monkeypatch.setattr("cgr_gwas_qc.cli.config.TODAY", "01012021")
     test_path = _get_cgems_production_run_dir("TestProject")
     assert CGEMS_QC_DIR / "TestProject/builds/QC_v1_01012021" == test_path
 
 
+@pytest.mark.skipif(
+    skip_condition,
+    reason=f"Skipping test because {CGEMS_QC_DIR} does not exist or is not accessible.",
+)
 def test_get_cgems_production_run_dir_increment_if_previous_runs(monkeypatch):
     def glob(*args, **kwargs):
         """Return 2 previous runs"""


### PR DESCRIPTION
## What
This PR updates the unit test `test_get_cgems_production_run_dir` in `tests/cli/test_config.py` by adding a `skipif` decorator. This decorator allows the test to be skipped if `CGEMS_QC_DIR` is inaccessible.

## Why
When `CGEMS_QC_DIR` is unavailable (due to permission issues or running the test on a machine without access), the `test_get_cgems_production_run_dir` fails. Skipping the test in such scenarios avoids misleading failures. The test itself focuses on the function's functionality, not external directory access.

<br>

Fixes #336 