### PR TITLE
fix: Apply `max_time_hr` to `sample_level_ibd` rule (issue #334)

### DIFF
--- a/src/cgr_gwas_qc/models/config/workflow_params.py
+++ b/src/cgr_gwas_qc/models/config/workflow_params.py
@@ -92,7 +92,7 @@ class WorkflowParams(BaseModel):
 
     max_time_hr: Optional[int] = Field(
         None,
-        description="Allocates the specified number of hours for the execution of the ``sample_concordance_plink`` and ``population_level_ibd`` rules.",
+        description="Allocates the specified number of hours to the following rules: ``sample_concordance_plink``, ``sample_concordance_king``, ``sample_concordance_summary``, ``sample_level_ibd``, and ``population_level_ibd``.",
     )
 
     time_start: str = Field(

--- a/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
@@ -335,6 +335,9 @@ use rule genome from plink as sample_level_ibd with:
         out_prefix="sample_level/call_rate_2/samples_maf{maf}_ld{ld}",
     output:
         "sample_level/call_rate_2/samples_maf{maf}_ld{ld}.genome",
+    resources:
+        mem_mb=lambda wildcards, attempt, input: max((attempt + 1) * input.size_mb, 1024),
+        time_hr=lambda wildcards, attempt: BIG_TIME[attempt],
 
 
 rule sample_concordance_plink:


### PR DESCRIPTION
**What**
- Apply the ``max_time_hr`` feature to the ``sample_level_ibd`` rule within the ``sample_qc.smk`` sub-workflow.
- Update the ``workflow_params.py`` file to state all of the rules that ``max_time_hr`` affects.

**Why**
The ``sample_level_ibd`` rule is another time-intensive step in the pipeline, and can users have experienced timeout issues at this step when running it on large datasets with the standard time-allocation method. So this update ensures that if a user specifies ``max_time_hr`` in the ``config.yml``, it will allso apply to this rule.

This is and extension of PR #335.
Fixes #334