### PR TITLE
feat: Add `max_mem_mb` config option to set max memory available (issue #343)

### DIFF
--- a/src/cgr_gwas_qc/models/config/workflow_params.py
+++ b/src/cgr_gwas_qc/models/config/workflow_params.py
@@ -25,6 +25,7 @@ class WorkflowParams(BaseModel):
             lims_output_dir: /DCEG/CGF/Laboratory/LIMS/drop-box-prod/gwas_primaryqc/
             case_control_gwas: false
             max_time_hr:
+            max_mem_mb:
             time_start:
     """
 
@@ -92,7 +93,12 @@ class WorkflowParams(BaseModel):
 
     max_time_hr: Optional[int] = Field(
         None,
-        description="Allocates the specified number of hours to the following rules: ``sample_concordance_plink``, ``sample_concordance_king``, ``sample_concordance_summary``, ``sample_level_ibd``, and ``population_level_ibd``.",
+        description="The maximum amount of time that can be requested, in hours.",
+    )
+
+    max_mem_mb: Optional[int] = Field(
+        None,
+        description="The maximum amount of memory that can be requests, in megabytes.",
     )
 
     time_start: str = Field(

--- a/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
@@ -2,8 +2,8 @@ from cgr_gwas_qc import load_config
 
 cfg = load_config()
 
-mtime = cfg.config.workflow_params.max_time_hr
-BIG_TIME = dict.fromkeys(range(1, 4), mtime) if mtime else {1: 10, 2: 48, 3: 96}
+max_time = cfg.config.workflow_params.max_time_hr
+BIG_TIME = dict.fromkeys(range(1, 4), max_time) if max_time else {1: 10, 2: 48, 3: 96}
 
 use_contamination = (
     cfg.config.user_files.idat_pattern
@@ -335,9 +335,6 @@ use rule genome from plink as sample_level_ibd with:
         out_prefix="sample_level/call_rate_2/samples_maf{maf}_ld{ld}",
     output:
         "sample_level/call_rate_2/samples_maf{maf}_ld{ld}.genome",
-    resources:
-        mem_mb=lambda wildcards, attempt, input: max((attempt + 1) * input.size_mb, 1024),
-        time_hr=lambda wildcards, attempt: BIG_TIME[attempt],
 
 
 rule sample_concordance_plink:
@@ -356,7 +353,7 @@ rule sample_concordance_plink:
     output:
         "sample_level/concordance/plink.csv",
     resources:
-        mem_mb=lambda wc, attempt, input: max((attempt + 1) * input.size_mb, 1000),
+        mem_mb=lambda wc, attempt, input: max((attempt + 1) * input.size_mb, 1024),
         time_hr=lambda wildcards, attempt: BIG_TIME[attempt],
     script:
         "../scripts/concordance_table.py"
@@ -381,7 +378,7 @@ use rule relatedness from graf as sample_concordance_graf with:
     output:
         "sample_level/concordance/graf.tsv",
     resources:
-        mem_mb=lambda wc, attempt, input: max((attempt + 1) * input.size_mb, 1000),
+        mem_mb=lambda wc, attempt, input: max((attempt + 1) * input.size_mb, 1024),
     log:
         "sample_level/concordance/graf.log",
 
@@ -405,7 +402,7 @@ rule sample_concordance_king:
         "sample_level/concordance/king.log",
     threads: 8
     resources:
-        mem_mb=lambda wc, attempt, input: max((attempt + 1) * input.size_mb, 1000),
+        mem_mb=lambda wc, attempt, input: max((attempt + 1) * input.size_mb, 1024),
         time_hr=lambda wildcards, attempt: BIG_TIME[attempt],
     shell:
         # king does not always output all files so touch for snakemake
@@ -426,7 +423,7 @@ rule sample_concordance_summary:
     output:
         "sample_level/concordance/summary.csv",
     resources:
-        mem_mb=lambda wc, attempt, input: max((attempt + 1) * input.size_mb, 1000),
+        mem_mb=lambda wc, attempt, input: max((attempt + 1) * input.size_mb, 1024),
         time_hr=lambda wildcards, attempt: BIG_TIME[attempt],
     script:
         "../scripts/sample_concordance.py"
@@ -455,7 +452,7 @@ use rule grafpop_populations from grafpop as graf_populations with:
     output:
         "sample_level/ancestry/grafpop_populations.txt",
     resources:
-        mem_mb=lambda wc, attempt, input: max((attempt + 1) * input.size_mb, 1000),
+        mem_mb=lambda wc, attempt, input: max((attempt + 1) * input.size_mb, 1024),
     log:
         "sample_level/ancestry/grafpop_populations.log",
 

--- a/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
@@ -9,9 +9,6 @@ import math
 
 cfg = load_config()
 
-mtime = cfg.config.workflow_params.max_time_hr
-BIG_TIME = dict.fromkeys(range(1, 4), mtime) if mtime else {1: 8, 2: 24, 3: 48}
-
 
 localrules:
     all_subject_qc,
@@ -279,9 +276,6 @@ use rule genome from plink as population_level_ibd with:
         out_prefix="subject_level/{population}/subjects_maf{maf}_ld{ld}_ibd",
     output:
         "subject_level/{population}/subjects_maf{maf}_ld{ld}_ibd.genome",
-    resources:
-        mem_mb=lambda wildcards, attempt, input: max((attempt + 1) * input.size_mb, 1024),
-        time_hr=lambda wildcards, attempt: BIG_TIME[attempt],
 
 
 rule population_level_concordance_plink:


### PR DESCRIPTION
**What**
This PR introduces a new optional workflow parameter for the `config.yml` called `max_mem_mb`. Users can set this parameter to specify the maximum amount of memory they can request. When this option is set, the memory allocation will be as follows: `{1: max_mem / 3, 2: max_mem / 2, 3: max_mem}`. This allocation applies only to certain resource-intensive rules.

**Why**
We discovered that some memory-intensive rules, such as `sample_level_ibd`, require a significant amount of memory to execute. Previously, we had a fixed allocation request of `{1: 1024 * 4, 2: 1024 * 64, 3: 1024 * 250}`. However, some users may have constraints on the amount of memory they can request. This new parameter allows them to specify their available memory, enabling more flexible and efficient memory allocation.


Fixes #343 