### PR TITLE
report: Remove the sentence about low replicate concordance (issue #353)

### DIFF
--- a/src/cgr_gwas_qc/reporting/templates/qc_report.md.j2
+++ b/src/cgr_gwas_qc/reporting/templates/qc_report.md.j2
@@ -83,7 +83,6 @@ Internal QC samples (from the 1000G project) are added to each 96-well plate to 
 
 Similar to internal QC controls, technical replicates of study samples are included in every project to assess overall quality by comparing replicate concordance (proportion IBS2).
 In this project the minimum concordance of replicates was {{ sample_qc.expected_replicates.min_concordance | toPct | numFormat }}% and the mean concordance was {{ sample_qc.expected_replicates.mean_concordance | toPct | numFormat }}%.
-We removed {{ sample_qc.expected_replicates.num_low_concordance | numFormat }} study samples with low replicate concordance.
 
 ### Replicate Pruning (Subject Representative)
 


### PR DESCRIPTION
**What**
Remove the sentence "We removed {{ sample_qc.expected_replicates.num_low_concordance | numFormat }} study samples with low replicate concordance." from the `QC_Report.docx`. Discordant Replicates section 3.5.1.

**Why**
We are not actually removing them from the pipeline. For example, if you look in "Table 4a Summary of sample level exclusions" there is no row for mentioning removing these samples.



Fixes #353 

