### PR TITLE
fix: Unexpected replicate count incorrect when group of 3 or more (issue #352)

### DIFF
--- a/src/cgr_gwas_qc/workflow/scripts/qc_report_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/qc_report_table.py
@@ -187,6 +187,7 @@ _SUBJECT_QC_COLUMNS = [
     "Case/Control_Status",
     "Unexpected Replicate",
     "unexpected_replicate_ids",
+    "unexpected_replicate_status",
     "Expected_Sex",
     "Predicted_Sex",
     "ChrX_Inbreed_estimate",

--- a/src/cgr_gwas_qc/workflow/scripts/subject_qc_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/subject_qc_table.py
@@ -14,6 +14,7 @@ Internal Subject QC Report
     case_control, CASE_CONTROL_DTYPE, Phenotype status {Case, Control, QC, Unknown}
     is_unexpected_replicate, boolean, True if two subjects had high concordance.
     unexpected_replicate_ids, string, Concatenated Sample_IDs that are unexpected replicates.
+    unexpected_replicate_status, UNEXPECTED_REPLICATE_STATUS_DTYPE, Identifies unexpected replicates and their retainment status after contamination assessment.
     expected_sex, SEX_DTYPE, The expected sex from the provided sample sheet.
     predicted_sex, SEX_DTYPE, The predicted sex based on X chromosome heterozygosity.
     X_inbreeding_coefficient, float, The X chromosome F coefficient.
@@ -95,7 +96,7 @@ def main(
     )
 
 
-# Needed with graf-pop implementarion that returns Asian-Pacific_Islander which the hyphen isn't supported by snakemake wildcares
+# Needed with graf-pop implementation that returns Asian-Pacific_Islander which the hyphen isn't supported by snakemake wildcares
 def _fix_hyphen_in_ancestry_name(df: pd.DataFrame) -> pd.DataFrame:
     df["Ancestry"] = df["Ancestry"].str.replace("-", "_")
     return df
@@ -140,9 +141,10 @@ def _add_unexpected_replicate_ids(df: pd.DataFrame, sample_concordance_csv: Path
         .astype("string")
     )
 
-    return df.merge(flags.join(unexpected_ids), on="Group_By_Subject_ID", how="left").fillna(
+    df = df.merge(flags.join(unexpected_ids), on="Group_By_Subject_ID", how="left").fillna(
         {"is_unexpected_replicate": False}
     )
+    return df
 
 
 def _add_unexpected_replicate_status(df: pd.DataFrame) -> pd.DataFrame:
@@ -166,33 +168,38 @@ def _add_unexpected_replicate_status(df: pd.DataFrame) -> pd.DataFrame:
         # Check if unexpected replicate and extract information
         if row["is_unexpected_replicate"]:
             pair = row["unexpected_replicate_ids"].split("|")
-            current_subject = df.loc[
-                index, "Group_By_Subject_ID"
-            ]  # get the subject ID of current row
 
-            other_subject = "".join([str(subid) for subid in pair if subid != current_subject])
+            # get the subject ID of current row
+            current_subject = df.loc[index, "Group_By_Subject_ID"]
+            other_subjects = [subid.strip() for subid in pair if subid.strip() != current_subject]
 
             # Check contamination status of current subject
             if pd.isna(df.loc[index, "is_contaminated"]) or not df.loc[index, "is_contaminated"]:
-                other_subject_index = df[df["Group_By_Subject_ID"] == other_subject].index
-                other_subject_row = df.iloc[other_subject_index]
-                is_contaminated = other_subject_row["is_contaminated"]
+                # Check contamination status of other subjects
+                other_contaminated = df[df["Group_By_Subject_ID"].isin(other_subjects)][
+                    "is_contaminated"
+                ]
 
-                # Update status of current subject if other subject is contaminated
-                if is_contaminated.all():
+                # other_contam=False if any are_not contaminated or are NaN
+                if any(other_contaminated.isin([False])) or any(pd.isna(other_contaminated)):
+                    other_contaminated = False
+                else:
+                    other_contaminated = True
+
+                # Update status of current subject if other subjects are contaminated
+                # all other subjects are contaminated (yes status change)
+                if other_contaminated:
                     df.loc[index, "unexpected_replicate_status"] = 1
                     df.loc[index, "is_unexpected_replicate"] = False
-
                 else:
-                    # Neither contaminated, no change
+                    # Not all other subjects are not contaminated (no status change)
                     df.loc[index, "unexpected_replicate_status"] = 3
 
             # Current subject is contaminated (no status change)
             else:
                 df.loc[index, "unexpected_replicate_status"] = 2
-                current_subject = typer.style(current_subject, fg=typer.colors.RED)
 
-        # Not an unexpected replicate (no change)
+        # Not an unexpected replicate (no status change)
         else:
             df.loc[index, "unexpected_replicate_status"] = 0
 


### PR DESCRIPTION
**What**
* The `subject_qc_table.py` script has a function called `_add_unexpected_replicate_status` that we added with PR #322. This PR edits this function to handle cases when the list of samples in`unexpected_replicate_ids` is greater than 2. 
* This PR also adds the `unexpected_replicate_status` to the `QC_Report.xlsx`.

**Why**
* The code was originally written expecting the `unexpected_replicate_ids` value to be a pair of samples. So when there were cases where there were 3 or more samples in this group, the code wouldn't work correctly. In particular, we saw that the `is_unexpected_replicate` status was erroneously changing to `False` for each these samples. So now with this PR, it will appropriately handle those cases.
* The `unexpected_replicate_status` column was not being added to the `QC_Report.xlsx` even thought it was described in the `QC_Report_Data_Dictionary.xlsx`. So this PR corrects that. 


Fixes #352 and #269.