### PR TITLE
Threads via variable.

### DIFF
--- a/src/cgr_gwas_qc/cli/submit.py
+++ b/src/cgr_gwas_qc/cli/submit.py
@@ -79,9 +79,9 @@ def main(
         "If you have a very large project >50k samples, you may want to increase the number of CPUs used for this job. "
         "Ignored if using `--cgems`.",
     ),
-    max_threads: int = typer.Option(
+    cores: int = typer.Option(
         8,
-        help="The maximum number of threads a rule can request. If pipeline is executed in `cluster_mode`, this will scale down the threads to `max-threads`.",
+        help="The maximum number of threads a rule can request. If pipeline is executed in `cluster_mode`, this will scale down the threads to `cores`.",
     ),
 ):
     """Submit the CGR GwasQcPipeline to a cluster for execution.
@@ -147,8 +147,8 @@ def main(
     if subworkflow:
         payload["added_options"] += f"--subworkflow {subworkflow} "  # type: ignore
 
-    if max_threads:
-        payload["added_options"] += f"--max-threads {max_threads} "
+    if cores:
+        payload["added_options"] += f"--cores {cores} "
 
     # add global config options only used in cluster mode.
     payload["added_options"] += "--config {} ".format(  # type: ignore

--- a/src/cgr_gwas_qc/cluster_profiles/biowulf/config.yaml
+++ b/src/cgr_gwas_qc/cluster_profiles/biowulf/config.yaml
@@ -10,4 +10,5 @@ printshellcmds: true
 rerun-incomplete: true
 restart-times: 3
 use-conda: true
-cores: 56
+cores: &cores 56
+max-threads: *cores

--- a/src/cgr_gwas_qc/cluster_profiles/biowulf/config.yaml
+++ b/src/cgr_gwas_qc/cluster_profiles/biowulf/config.yaml
@@ -10,4 +10,4 @@ printshellcmds: true
 rerun-incomplete: true
 restart-times: 3
 use-conda: true
-max-threads: 56
+cores: 56

--- a/src/cgr_gwas_qc/cluster_profiles/ccad2/config.yaml
+++ b/src/cgr_gwas_qc/cluster_profiles/ccad2/config.yaml
@@ -10,4 +10,5 @@ printshellcmds: true
 rerun-incomplete: true
 restart-times: 3
 use-conda: true
-cores: 44
+cores: &cores 44
+max-threads: *cores

--- a/src/cgr_gwas_qc/cluster_profiles/ccad2/config.yaml
+++ b/src/cgr_gwas_qc/cluster_profiles/ccad2/config.yaml
@@ -10,4 +10,4 @@ printshellcmds: true
 rerun-incomplete: true
 restart-times: 3
 use-conda: true
-max-threads: 44
+cores: 44

--- a/src/cgr_gwas_qc/cluster_profiles/ccad2/submit.py
+++ b/src/cgr_gwas_qc/cluster_profiles/ccad2/submit.py
@@ -17,7 +17,7 @@ from cgr_gwas_qc.cluster_profiles import (
 
 @dataclass
 class Ccad2Options(ClusterOptions):
-    queue: Set[str] = field(default_factory=lambda: {"defq", "bigmemq"})
+    queue: Set[str] = field(default_factory=lambda: {"defq", "bigmemq", "cgrq"})
     log: str = "logs/{rulename}_{job_id}.%j"
 
     def __str__(self):

--- a/src/cgr_gwas_qc/cluster_profiles/ccad2/submit.py
+++ b/src/cgr_gwas_qc/cluster_profiles/ccad2/submit.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import grp
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Set
@@ -15,9 +16,16 @@ from cgr_gwas_qc.cluster_profiles import (
 )
 
 
+def get_allowed_queue():
+    if "ncicgr_staff" in [g.gr_name for g in grp.getgrall()]:
+        return {"defq", "bigmemq", "cgrq"}
+    else:
+        return {"defq", "bigmemq"}
+
+
 @dataclass
 class Ccad2Options(ClusterOptions):
-    queue: Set[str] = field(default_factory=lambda: {"defq", "bigmemq", "cgrq"})
+    queue: Set[str] = field(default_factory=get_allowed_queue)
     log: str = "logs/{rulename}_{job_id}.%j"
 
     def __str__(self):

--- a/src/cgr_gwas_qc/cluster_profiles/slurm_generic/config.yaml
+++ b/src/cgr_gwas_qc/cluster_profiles/slurm_generic/config.yaml
@@ -10,4 +10,5 @@ printshellcmds: true
 rerun-incomplete: true
 restart-times: 3
 use-conda: true
-cores: 8
+cores: &cores 8
+max-threads: *cores

--- a/src/cgr_gwas_qc/cluster_profiles/slurm_generic/config.yaml
+++ b/src/cgr_gwas_qc/cluster_profiles/slurm_generic/config.yaml
@@ -10,4 +10,4 @@ printshellcmds: true
 rerun-incomplete: true
 restart-times: 3
 use-conda: true
-max-threads: 8
+cores: 8

--- a/src/cgr_gwas_qc/workflow/modules/bcf.smk
+++ b/src/cgr_gwas_qc/workflow/modules/bcf.smk
@@ -40,7 +40,7 @@ rule convert_bcf_to_plink_bed:
         cfg.conda("plink2-0")
     benchmark:
         "benchmarks/convert_bcf_to_plink_bed." + str(len(cfg.ss)) + ".tsv"
-    threads: 44
+    threads: workflow.cores
     resources:
         mem_mb=ceil((0.07 * len(cfg.ss))) + 1024,
         time_hr=ceil((0.11 * len(cfg.ss)) / 3600),

--- a/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
@@ -248,7 +248,7 @@ if cfg.config.user_files.gtc_pattern:
                         + str(len(cfg.ss))
                         + ".tsv"
                     )
-                threads: 44
+                threads: workflow.cores
                 resources:
                     time_hr=ceil((len(cfg.ss) * 0.2) / 3600 + 1),
                     mem_mb=len(cfg.cluster_groups) * 70,


### PR DESCRIPTION
1. Renames the `max_threads` parameter to `cores` (925d5c67ae0e2ff3e6fc5097023b4cc9933e072a).
2. Uses `workflow.cores` to define threads in rules `convert_bcf_to_plink_bed` and `merge_gtc_to_bcf_batches` instead of hardcoded 44 (acc7df78706003895b28d8f677a79c3ed38cc961).

The `max_threads` seems inaccessible at the rule level. The `cores` does the trick. They both seem synonymous anyway per the Snakemake documentation.

Please let me know if you encounter any issues. Thanks.
