### PR TITLE
Reduces memory usage and time for plink rule genome.

### DIFF
--- a/src/cgr_gwas_qc/workflow/modules/idat.smk
+++ b/src/cgr_gwas_qc/workflow/modules/idat.smk
@@ -43,7 +43,7 @@ rule idat2gtc:
         dragena_location=cfg.config.workflow_params.dragena_location,
     output:
         output_folder=directory("sample_level/gtcs"),
-    threads: 44
+    threads: workflow.cores
     envmodules:
         "dragena/1.0.0",
     shell:

--- a/src/cgr_gwas_qc/workflow/modules/plink.smk
+++ b/src/cgr_gwas_qc/workflow/modules/plink.smk
@@ -51,6 +51,7 @@ rule sample_call_rate_filter:
         touch {output.nosex}
         """
 
+
 rule snp_call_rate_filter:
     input:
         bed="{prefix}.bed",
@@ -77,6 +78,7 @@ rule snp_call_rate_filter:
         plink --bed {input.bed} --bim {input.bim} --fam {input.fam} --geno {params.geno} --make-bed --threads {threads} --memory {resources.mem_mb} --out {params.out_prefix}
         touch {output.nosex}
         """
+
 
 rule maf_filter:
     """Filter SNPs based on minor allele frequency."""
@@ -140,6 +142,7 @@ rule ld_filter:
         plink --bed {input.bed} --bim {input.bim} --fam {input.fam} --extract {input.to_keep} --make-bed --threads {threads} --memory {resources.mem_mb} --out {params.out_prefix}
         touch {output.nosex}
         """
+
 
 rule snps_only_filter:
     """Exclude all variants with one or more multi-character allele codes"""
@@ -249,6 +252,7 @@ rule remove_ids:
         touch {output.nosex}
         """
 
+
 rule keep_bfile:
     """Tell snakemake to keep the file.
 
@@ -280,6 +284,7 @@ rule keep_bfile:
         touch {output.nosex}
         """
 
+
 ################################################################################
 # Converters
 ################################################################################
@@ -308,6 +313,7 @@ rule rename_ids:
         plink --bed {input.bed} --bim {input.bim} --fam {input.fam} --update-ids {input.id_map} --make-bed --threads {threads} --memory {resources.mem_mb} --out {params.out_prefix}
         touch {output.nosex}
         """
+
 
 rule bed_to_ped:
     input:
@@ -388,6 +394,7 @@ rule ld:
         sleep 10 && plink --bed {input.bed} --bim {input.bim} --fam {input.fam} --indep-pairwise 50 5 {params.r2} --threads {threads} --memory {resources.mem_mb} --out {params.out_prefix}
         touch {output.nosex}
         """
+
 
 rule miss:
     """Runs ``plink`` missingness statistics.
@@ -538,7 +545,7 @@ rule genome:
         "--memory {resources.mem_mb} "
         "--out {params.out_prefix}.chunk "
         "--parallel $idx {params.n_chunks} ';"
-        "cat {params.out_prefix}.chunk* > {params.out_prefix}.genome ;"
+        "cat {params.out_prefix}.chunk.genome.* > {params.out_prefix}.genome ;"
         "rm {params.out_prefix}.chunk*"
 
 

--- a/src/cgr_gwas_qc/workflow/modules/plink.smk
+++ b/src/cgr_gwas_qc/workflow/modules/plink.smk
@@ -1,4 +1,5 @@
 from cgr_gwas_qc import load_config
+from math import floor
 
 cfg = load_config()
 
@@ -101,7 +102,7 @@ rule maf_filter:
     resources:
         mem_mb=lambda wildcards, attempt: attempt * 1024,
     shell:
-        """ 
+        """
         plink --bed {input.bed} --bim {input.bim} --fam {input.fam} --maf {params.maf} --make-bed --threads {threads} --memory {resources.mem_mb} --out {params.out_prefix}
         touch {output.nosex}
         """
@@ -512,25 +513,33 @@ rule genome:
         ibd_min=cfg.config.software_params.ibd_pi_hat_min,
         ibd_max=cfg.config.software_params.ibd_pi_hat_max,
         out_prefix="{prefix}",
+        n_chunks=2,
+        n_threads=min(10, workflow.cores),
+        n_tasks=floor(max(1, workflow.cores / min(10, workflow.cores))),
     output:
         "{prefix}.genome",
-    threads: lambda wildcards, attempt: attempt * 2
+    threads: workflow.cores
     resources:
-        mem_mb=lambda wildcards, attempt: PLINK_BIG_MEM[attempt],
-        time_hr=lambda wildcards, attempt: BIG_TIME[attempt],
+        mem_mb=lambda wildcards, attempt: attempt * 16000,
+        time_hr=lambda wildcards, attempt: attempt * 3,
     conda:
         cfg.conda("plink2")
     shell:
-        "sleep 10 && plink "
+        "seq 1 {params.n_chunks} |"
+        "xargs -n1 -P{params.n_tasks} -I 'piece' bash -c 'idx=piece;"
+        "plink "
         "--bed {input.bed} "
         "--bim {input.bim} "
         "--fam {input.fam} "
         "--genome full "
         "--min {params.ibd_min} "
         "--max {params.ibd_max} "
-        "--threads {threads} "
+        "--threads {params.n_threads} "
         "--memory {resources.mem_mb} "
-        "--out {params.out_prefix}"
+        "--out {params.out_prefix}.chunk "
+        "--parallel $idx {params.n_chunks} ';"
+        "cat {params.out_prefix}.chunk* > {params.out_prefix}.genome ;"
+        "rm {params.out_prefix}.chunk*"
 
 
 rule het:

--- a/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
@@ -372,7 +372,7 @@ use rule genome from plink as sample_level_ibd with:
         ibd_min=cfg.config.software_params.ibd_pi_hat_min,
         ibd_max=cfg.config.software_params.ibd_pi_hat_max,
         out_prefix="sample_level/call_rate_2/samples_maf{maf}_ld{ld}",
-        n_chunks=ceil(len(cfg.cluster_groups) / 2),
+        n_chunks=max(2, ceil(len(cfg.cluster_groups) / 2)),
         n_threads=min(10, workflow.cores),
         n_tasks=floor(max(1, workflow.cores / min(10, workflow.cores))),
     output:

--- a/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
@@ -1,4 +1,5 @@
 from cgr_gwas_qc import load_config
+from math import ceil, floor
 
 cfg = load_config()
 
@@ -371,6 +372,9 @@ use rule genome from plink as sample_level_ibd with:
         ibd_min=cfg.config.software_params.ibd_pi_hat_min,
         ibd_max=cfg.config.software_params.ibd_pi_hat_max,
         out_prefix="sample_level/call_rate_2/samples_maf{maf}_ld{ld}",
+        n_chunks=ceil(len(cfg.cluster_groups) / 2),
+        n_threads=min(10, workflow.cores),
+        n_tasks=floor(max(1, workflow.cores / min(10, workflow.cores))),
     output:
         "sample_level/call_rate_2/samples_maf{maf}_ld{ld}.genome",
 

--- a/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
@@ -274,7 +274,7 @@ use rule genome from plink as population_level_ibd with:
         ibd_min=cfg.config.software_params.ibd_pi_hat_min,
         ibd_max=cfg.config.software_params.ibd_pi_hat_max,
         out_prefix="subject_level/{population}/subjects_maf{maf}_ld{ld}_ibd",
-        n_chunks=ceil(len(cfg.cluster_groups) / 2),
+        n_chunks=max(2, ceil(len(cfg.cluster_groups) / 2)),
         n_threads=min(10, workflow.cores),
         n_tasks=floor(max(1, workflow.cores / min(10, workflow.cores))),
     output:

--- a/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
@@ -6,6 +6,7 @@ from cgr_gwas_qc import load_config
 from cgr_gwas_qc.workflow.scripts import subject_qc_table
 import shutil
 import math
+from math import ceil, floor
 
 cfg = load_config()
 

--- a/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
@@ -274,6 +274,9 @@ use rule genome from plink as population_level_ibd with:
         ibd_min=cfg.config.software_params.ibd_pi_hat_min,
         ibd_max=cfg.config.software_params.ibd_pi_hat_max,
         out_prefix="subject_level/{population}/subjects_maf{maf}_ld{ld}_ibd",
+        n_chunks=ceil(len(cfg.cluster_groups) / 2),
+        n_threads=min(10, workflow.cores),
+        n_tasks=floor(max(1, workflow.cores / min(10, workflow.cores))),
     output:
         "subject_level/{population}/subjects_maf{maf}_ld{ld}_ibd.genome",
 


### PR DESCRIPTION
# Description:
This PR reduces memory usage and time for plink rule genome. 

1. It builds on the PR #361 and assigns the threads as `workflow.cores` which reduces time.
2. It introduces .genome computation in batches and controls the batches executed simultaneously to reduce memory usage.

# Testing:
It reduces the compute time for `sample_level_ibd` to about 110 min with 12Gb memory used for a sample size of 123,244. The same efficiency gains should apply to rule `population_level_ibd`.