### PR TITLE
Skip King and Graf concordance checks.

### DIFF
--- a/docs/sub_workflows/sample_qc.rst
+++ b/docs/sub_workflows/sample_qc.rst
@@ -93,6 +93,7 @@ Replicate Concordance
    - ``software_params.pi_hat_threshold``
    - ``workflow_params.remove_contam``
    - ``workflow_params.remove_rep_discordant``
+   - ``workflow_params.concordance_tools``
 
 **Major Outputs**:
 
@@ -100,10 +101,11 @@ Replicate Concordance
 
 It is common to include multiple replicates for a subset of samples as a QC metric.
 Here we check these replicates and make sure that they are highly concordant.
-We report 3 methods for checking relatedness/concordance (PLINK IBD, GRAF, and KING).
-We mostly rely on IBD results but report the others in our summary tables.
-For all three methods, we do all pairwise comparisons to determine which samples are related/replicated.
-We flag two samples as concordant (``is_ge_concordance``) if concordance (proportion IBD2) > dup_concordance_cutoff.
+The pipeline can check for relatedness/concordance using three tools : PLINK IBD, GRAF, and KING.
+We only rely on and report IBD results in our summary tables.
+To save compute resources on large datasets, the outputs for GRAF and KING relatedness checks can be disabled
+by setting ``workflow_params.concordance_tools.graf`` and ``workflow_params.concordance_tools.king`` to `False`.
+In the sumary tables, we flag two samples as concordant (``is_ge_concordance``) if concordance (proportion IBD2) > dup_concordance_cutoff.
 We flag two samples as related (``is_ge_pi_hat``) if PLINK's PI_HAT is >= pi_hat_threshold.
 
 Ancestry

--- a/docs/sub_workflows/sample_qc.rst
+++ b/docs/sub_workflows/sample_qc.rst
@@ -105,6 +105,10 @@ The pipeline can check for relatedness/concordance using three tools : PLINK IBD
 We only rely on and report IBD results in our summary tables.
 To save compute resources on large datasets, the outputs for GRAF and KING relatedness checks can be disabled
 by setting ``workflow_params.concordance_tools.graf`` and ``workflow_params.concordance_tools.king`` to `False`.
+If PLINK IBD is not needed either, ``workflow_params.concordance_tools.plink`` can also be set to `False`.
+In this case, PLINK IBD will be skipped. Since PLINK IBD is the main tool used for replicate checks,
+columns related to replicate checks will be empty in the sample_qc table including `Expected Replicate Discordance` and `Unexpected Replicate`.
+The workflow will sucessfully complete the sample_qc with all other QC metrics but not proceed to subject QC.
 In the sumary tables, we flag two samples as concordant (``is_ge_concordance``) if concordance (proportion IBD2) > dup_concordance_cutoff.
 We flag two samples as related (``is_ge_pi_hat``) if PLINK's PI_HAT is >= pi_hat_threshold.
 

--- a/docs/sub_workflows/sample_qc.rst
+++ b/docs/sub_workflows/sample_qc.rst
@@ -108,8 +108,8 @@ by setting ``workflow_params.concordance_tools.graf`` and ``workflow_params.conc
 If PLINK IBD is not needed either, ``workflow_params.concordance_tools.plink`` can also be set to `False`.
 In this case, PLINK IBD will be skipped. Since PLINK IBD is the main tool used for replicate checks,
 columns related to replicate checks will be empty in the sample_qc table including `Expected Replicate Discordance` and `Unexpected Replicate`.
-The workflow will sucessfully complete the sample_qc with all other QC metrics but not proceed to subject QC.
-In the sumary tables, we flag two samples as concordant (``is_ge_concordance``) if concordance (proportion IBD2) > dup_concordance_cutoff.
+The workflow will successfully complete the sample_qc with all other QC metrics but not proceed to subject QC.
+In the summary tables, we flag two samples as concordant (``is_ge_concordance``) if concordance (proportion IBD2) > dup_concordance_cutoff.
 We flag two samples as related (``is_ge_pi_hat``) if PLINK's PI_HAT is >= pi_hat_threshold.
 
 Ancestry

--- a/src/cgr_gwas_qc/models/config/workflow_params.py
+++ b/src/cgr_gwas_qc/models/config/workflow_params.py
@@ -16,6 +16,10 @@ class ConcordanceTools(BaseModel):
         False,
         description="Is king relateness results needed? Even if True, the results won't be used in sample_concordance.",
     )
+    plink: bool = Field(
+        True,
+        description="Is plink ibd relateness results needed? It is the primary tool used in sample_qc report. If false, no replicate/relatedness check would be considered in sample_qc",
+    )
 
 
 class WorkflowParams(BaseModel):

--- a/src/cgr_gwas_qc/models/config/workflow_params.py
+++ b/src/cgr_gwas_qc/models/config/workflow_params.py
@@ -7,6 +7,17 @@ from pydantic import BaseModel, Field
 timestr = time.strftime("%Y%m%d%H%M%S")
 
 
+class ConcordanceTools(BaseModel):
+    graf: bool = Field(
+        False,
+        description="Is graf relatedness results needed? Even if True, the results won't be used in sample_concordance.",
+    )
+    king: bool = Field(
+        False,
+        description="Is king relateness results needed? Even if True, the results won't be used in sample_concordance.",
+    )
+
+
 class WorkflowParams(BaseModel):
     """This set of parameters control what parts and how the workflow is run.
 
@@ -31,6 +42,9 @@ class WorkflowParams(BaseModel):
             additional_params_for_gtc2bcf: --use-gtc-sample-names
             convert_idat2gtc: false
             dragena_location:
+            concordance_tools:
+                graf: false
+                king: false
     """
 
     subject_id_column: str = Field(
@@ -132,6 +146,11 @@ class WorkflowParams(BaseModel):
     dragena_location: str = Field(
         None,
         description="Path to dragena binary. If dragena is not available as a module on HPC and IDAT entry_point is used, `dragena_location` will be used to convert idat2gtc.",
+    concordance_tools: Optional["ConcordanceTools"] = Field(
+        ConcordanceTools(),
+        description="The sample_concordance_summary only uses Plink."
+        "If the outputs of graf and king relationship checks are needed, this option can be configured"
+        "Please note if even graf and king reledness checks are requested and executed, these would be for reference purpose only and not considered sample_concordance_summary.",
     )
 
     @staticmethod

--- a/src/cgr_gwas_qc/models/config/workflow_params.py
+++ b/src/cgr_gwas_qc/models/config/workflow_params.py
@@ -146,6 +146,8 @@ class WorkflowParams(BaseModel):
     dragena_location: str = Field(
         None,
         description="Path to dragena binary. If dragena is not available as a module on HPC and IDAT entry_point is used, `dragena_location` will be used to convert idat2gtc.",
+    )
+
     concordance_tools: Optional["ConcordanceTools"] = Field(
         ConcordanceTools(),
         description="The sample_concordance_summary only uses Plink."

--- a/src/cgr_gwas_qc/models/config/workflow_params.py
+++ b/src/cgr_gwas_qc/models/config/workflow_params.py
@@ -9,21 +9,21 @@ timestr = time.strftime("%Y%m%d%H%M%S")
 
 class ConcordanceTools(BaseModel):
     graf: bool = Field(
-        False,
-        description="Is graf relatedness results needed? Even if True, the results won't be used in sample_concordance.",
+        True,
+        description="Are graf relatedness results needed? Even if True, the results won't be used in sample_concordance.",
     )
     king: bool = Field(
-        False,
-        description="Is king relateness results needed? Even if True, the results won't be used in sample_concordance.",
+        True,
+        description="Are king relateness results needed? Even if True, the results won't be used in sample_concordance.",
     )
     plink: bool = Field(
         True,
-        description="Is plink ibd relateness results needed? It is the primary tool used in sample_qc report. If false, no replicate/relatedness check would be considered in sample_qc",
+        description="Are plink ibd relateness results needed? It is the primary tool used in sample_qc report. If false, no replicate/relatedness check would be considered in sample_qc",
     )
 
 
 class WorkflowParams(BaseModel):
-    """This set of parameters control what parts and how the workflow is run.
+    """This set of parameters controls which parts of the workflow are run and how they are executed
 
     .. code-block:: yaml
 
@@ -47,8 +47,9 @@ class WorkflowParams(BaseModel):
             convert_idat2gtc: false
             dragena_location:
             concordance_tools:
-                graf: false
-                king: false
+                graf: true
+                king: true
+                plink: true
     """
 
     subject_id_column: str = Field(
@@ -156,7 +157,7 @@ class WorkflowParams(BaseModel):
         ConcordanceTools(),
         description="The sample_concordance_summary only uses Plink."
         "If the outputs of graf and king relationship checks are needed, this option can be configured"
-        "Please note if even graf and king reledness checks are requested and executed, these would be for reference purpose only and not considered sample_concordance_summary.",
+        "Please note even if graf and king relatedness checks are requested and executed, these would be for reference purpose only and not considered sample_concordance_summary.",
     )
 
     @staticmethod

--- a/src/cgr_gwas_qc/workflow/Snakefile
+++ b/src/cgr_gwas_qc/workflow/Snakefile
@@ -19,85 +19,19 @@ rule all:
 ################################################################################
 # Import All Sub-workflows
 ################################################################################
-targets = []
 
 
-module entry_points:
-    snakefile:
-        cfg.subworkflow("entry_points")
-    config:
-        config
+include: cfg.subworkflow("entry_points")
+include: cfg.subworkflow("sample_qc")
 
 
-use rule * from entry_points
+targets = rules.all_sample_qc.input + rules.all_entry_points.input
+if cfg.config.workflow_params.concordance_tools.plink:
 
+    include: cfg.subworkflow("delivery")
+    include: cfg.subworkflow("subject_qc")
 
-targets.extend(entry_points.targets)
-
-
-module sample_qc:
-    snakefile:
-        cfg.subworkflow("sample_qc")
-    config:
-        config
-
-
-use rule * from sample_qc
-
-
-targets.extend(sample_qc.targets)
-
-
-if sample_qc.use_contamination or cfg.config.user_files.bcf:
-
-    module contamination:
-        snakefile:
-            cfg.subworkflow("contamination")
-        config:
-            config
-
-    use rule * from contamination
-
-    targets.extend(contamination.targets)
-
-
-if sample_qc.use_contamination or cfg.config.user_files.bcf:
-
-    module intensity_check:
-        snakefile:
-            cfg.subworkflow("intensity_check")
-        config:
-            config
-
-    use rule * from intensity_check
-
-    targets.extend(intensity_check.targets)
-
-
-module subject_qc:
-    snakefile:
-        cfg.subworkflow("subject_qc")
-    config:
-        config
-
-
-use rule * from subject_qc
-
-
-targets.extend(subject_qc.targets)
-
-
-module delivery:
-    snakefile:
-        cfg.subworkflow("delivery")
-    config:
-        config
-
-
-use rule * from delivery
-
-
-targets.extend(delivery.targets)
+    targets.extend(rules.all_subject_qc.input + rules.all_delivery.input)
 
 
 ################################################################################

--- a/src/cgr_gwas_qc/workflow/scripts/sample_concordance.py
+++ b/src/cgr_gwas_qc/workflow/scripts/sample_concordance.py
@@ -87,8 +87,6 @@ def read(filename: PathLike):
 def main(
     sample_sheet_csv: Path,
     plink_file: Path,
-    graf_file: Path,
-    king_file: Path,
     outfile: Path,
 ):
     ss = sample_sheet.read(sample_sheet_csv)

--- a/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
@@ -165,8 +165,8 @@ def main(
         ..., help="Path to plink_filter_call_rate_1/samples.sexcheck"
     ),
     ancestry: Path = typer.Argument(..., help="Path to ancestry/graf_ancestry_calls.txt"),
-    sample_concordance_csv: Path = typer.Argument(..., help=""),
     # Optional inputs
+    sample_concordance_csv: Optional[Path] = typer.Option(None, help=""),
     contam: Optional[Path] = typer.Option(
         None, help="Path to sample_filters/agg_contamination_test.csv"
     ),
@@ -174,6 +174,7 @@ def main(
         None, help="Path to sample_filters/agg_median_idat_intensity.csv"
     ),
     # Params
+    concordance_checked: bool = True,
     remove_contam: bool = True,
     remove_rep_discordant: bool = True,
     # Outputs
@@ -190,13 +191,10 @@ def main(
         sample_concordance_csv,
         contam,
         intensity,
+        concordance_checked,
     )
 
-    add_qc_columns(
-        sample_qc,
-        remove_contam,
-        remove_rep_discordant,
-    )
+    add_qc_columns(sample_qc, remove_contam, remove_rep_discordant, concordance_checked)
 
     sample_qc = sample_qc.rename(
         columns={
@@ -215,9 +213,10 @@ def build(
     imiss_cr2: Path,
     sexcheck_cr1: Path,
     ancestry: Path,
-    sample_concordance_csv: Path,
+    sample_concordance_csv: Optional[Path],
     contam: Optional[Path],
     intensity: Optional[Path],
+    concordance_checked: bool,
 ) -> pd.DataFrame:
     Sample_IDs = ss.index
     return (
@@ -229,7 +228,7 @@ def build(
                 _read_imiss(imiss_cr2, Sample_IDs, "Call_Rate_2"),
                 _read_sexcheck_cr1(sexcheck_cr1, ss.expected_sex),
                 _read_ancestry(ancestry, Sample_IDs),
-                _read_concordance(sample_concordance_csv, Sample_IDs),
+                _read_concordance(sample_concordance_csv, Sample_IDs, concordance_checked),
                 _read_contam(contam, Sample_IDs),
                 _read_intensity(intensity, Sample_IDs),
                 # TO-ADD: call function you created to parse/summarize new file
@@ -371,7 +370,9 @@ def _read_SNPweights(file_name: Path, Sample_IDs: pd.Index) -> pd.DataFrame:
     )
 
 
-def _read_concordance(filename: Path, Sample_IDs: pd.Index) -> pd.DataFrame:
+def _read_concordance(
+    filename: Optional[Path], Sample_IDs: pd.Index, concordance_checked: bool
+) -> pd.DataFrame:
     """Create a flag of known replicates that show low concordance.
 
     Given a set of samples that are known to be from the same Subject. Flag
@@ -384,22 +385,29 @@ def _read_concordance(filename: Path, Sample_IDs: pd.Index) -> pd.DataFrame:
               a concordance below the supplied threshold. Otherwise False.
             - is_unexpected_replicate
     """
-    df = sample_concordance.read(filename)
-    return (
-        df.melt(
-            id_vars=["is_discordant_replicate", "is_unexpected_replicate"],
-            value_vars=["Sample_ID1", "Sample_ID2"],
-            var_name="To_Drop",
-            value_name="Sample_ID",
+    if concordance_checked:
+        df = sample_concordance.read(filename)
+        return (
+            df.melt(
+                id_vars=["is_discordant_replicate", "is_unexpected_replicate"],
+                value_vars=["Sample_ID1", "Sample_ID2"],
+                var_name="To_Drop",
+                value_name="Sample_ID",
+            )
+            .drop("To_Drop", axis=1)
+            .groupby("Sample_ID")
+            .max()  # Flag a sample as True if it is True for any comparison.
+            .astype("boolean")
+            .reindex(Sample_IDs)
+            .replace("", False)
+            .fillna(False)
         )
-        .drop("To_Drop", axis=1)
-        .groupby("Sample_ID")
-        .max()  # Flag a sample as True if it is True for any comparison.
-        .astype("boolean")
-        .reindex(Sample_IDs)
-        .replace("", False)
-        .fillna(False)
-    )
+    else:
+        return pd.DataFrame(
+            {"is_discordant_replicate": pd.NA, "is_unexpected_replicate": pd.NA},
+            index=Sample_IDs,
+            dtype="boolean",
+        )
 
 
 def _read_contam(file_name: Optional[Path], Sample_IDs: pd.Index) -> pd.DataFrame:
@@ -463,13 +471,10 @@ def add_qc_columns(
     sample_qc: pd.DataFrame,
     remove_contam: bool,
     remove_rep_discordant: bool,
+    concordance_checked: bool,
 ) -> pd.DataFrame:
     add_call_rate_flags(sample_qc)
-    _add_analytic_exclusion(
-        sample_qc,
-        remove_contam,
-        remove_rep_discordant,
-    )
+    _add_analytic_exclusion(sample_qc, remove_contam, remove_rep_discordant, concordance_checked)
     _add_identifiler(sample_qc)
     _add_subject_representative(sample_qc)
     _add_subject_dropped_from_study(sample_qc)
@@ -571,6 +576,7 @@ def _add_analytic_exclusion(
     sample_qc: pd.DataFrame,
     remove_contam: bool,
     remove_rep_discordant: bool,
+    concordance_checked: bool,
 ) -> pd.DataFrame:
     """Adds a flag to remove samples based on provided conditions.
 
@@ -586,12 +592,13 @@ def _add_analytic_exclusion(
         "is_cr2_filtered": "Call Rate 2 Filtered",
     }
 
-    sample_qc = _retain_valid_discordant_replicates(sample_qc)
+    if concordance_checked:
+        sample_qc = _retain_valid_discordant_replicates(sample_qc)
 
     if remove_contam:
         exclusion_criteria["is_contaminated"] = "Contamination"
 
-    if remove_rep_discordant:
+    if remove_rep_discordant and concordance_checked:
         exclusion_criteria["is_discordant_replicate"] = "Replicate Discordance"
 
     # adding this new column which is a boolean. Checks for any T in a  series (e.g., {F, F, F, F, T}.any())

--- a/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
+++ b/src/cgr_gwas_qc/workflow/scripts/sample_qc_table.py
@@ -576,7 +576,7 @@ def _add_analytic_exclusion(
     sample_qc: pd.DataFrame,
     remove_contam: bool,
     remove_rep_discordant: bool,
-    concordance_checked: bool,
+    concordance_checked: bool = True,
 ) -> pd.DataFrame:
     """Adds a flag to remove samples based on provided conditions.
 

--- a/src/cgr_gwas_qc/workflow/sub_workflows/contamination.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/contamination.smk
@@ -8,14 +8,14 @@ cfg = load_config()
 ################################################################################
 # Contamination Targets
 ################################################################################
-targets = [
+contamination_targets = [
     "sample_level/contamination/verifyIDintensity.csv",
 ]
 
 
 rule all_contamination:
     input:
-        targets,
+        contamination_targets,
 
 
 ################################################################################

--- a/src/cgr_gwas_qc/workflow/sub_workflows/delivery.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/delivery.smk
@@ -46,7 +46,7 @@ wildcard_constraints:
 ################################################################################
 # Delivery Targets
 ################################################################################
-targets = [
+delivery_targets = [
     "delivery/samples.bed",
     "delivery/samples.bim",
     "delivery/samples.fam",
@@ -70,7 +70,7 @@ if cfg.config.workflow_params.lims_upload:
     # The CGEMs/CCAD cluster has a cron job running that looks for this file in
     # the root run directory. If it is there then it will automatically upload
     # to the LIMs system. This is only useful on CGEMs/CCAD.
-    targets.append(
+    delivery_targets.append(
         output_pattern.format(
             prefix=cfg.config.workflow_params.lims_output_dir, file_type=file_type_lims, ext="csv"
         )
@@ -79,7 +79,7 @@ if cfg.config.workflow_params.lims_upload:
 
 rule all_delivery:
     input:
-        targets,
+        delivery_targets,
 
 
 ################################################################################

--- a/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
@@ -21,7 +21,7 @@ cfg = load_config()
 ################################################################################
 # Entry Points Targets
 ################################################################################
-targets = [
+entry_points_targets = [
     "sample_level/samples.bed",
     "sample_level/samples.bim",
     "sample_level/samples.fam",
@@ -30,7 +30,7 @@ targets = [
 
 rule all_entry_points:
     input:
-        targets,
+        entry_points_targets,
 
 
 ################################################################################

--- a/src/cgr_gwas_qc/workflow/sub_workflows/intensity_check.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/intensity_check.smk
@@ -8,14 +8,14 @@ cfg = load_config()
 ################################################################################
 # Intensity Targets
 ################################################################################
-targets = [
+intensity_check_targets = [
     "sample_level/contamination/median_idat_intensity.csv",
 ]
 
 
-rule all_contamination:
+rule all_intensity_check:
     input:
-        targets,
+        intensity_check_targets,
 
 
 ################################################################################

--- a/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
@@ -50,6 +50,13 @@ if use_contamination:
     targets.append("sample_level/contamination/summary.csv")
 
 
+if cfg.config.workflow_params.concordance_tools.king:
+    targets.append("sample_level/concordance/king.kin")
+
+if cfg.config.workflow_params.concordance_tools.graf:
+    targets.append("sample_level/concordance/graf.tsv")
+
+
 rule all_sample_qc:
     input:
         targets,
@@ -440,8 +447,6 @@ rule sample_concordance_summary:
     input:
         sample_sheet_csv="cgr_sample_sheet.csv",
         plink_file=rules.sample_concordance_plink.output[0],
-        graf_file=rules.sample_concordance_graf.output[0],
-        king_file=rules.sample_concordance_king.output.between_family,
     output:
         "sample_level/concordance/summary.csv",
     resources:

--- a/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
@@ -28,7 +28,7 @@ localrules:
 ################################################################################
 # Sample QC Targets
 ################################################################################
-targets = [
+sample_qc_targets = [
     "sample_level/sample_qc.csv",
     "sample_level/snp_qc.csv",
     "sample_level/summary_stats.txt",
@@ -41,7 +41,7 @@ targets = [
     "sample_level/ancestry.png",
 ]
 
-concordance_targets = [
+concordance_sample_qc_targets = [
     "sample_level/concordance/KnownReplicates.csv",
     "sample_level/concordance/InternalQcKnown.csv",
     "sample_level/concordance/StudySampleKnown.csv",
@@ -50,22 +50,26 @@ concordance_targets = [
 ]
 
 if use_contamination:
-    targets.append("sample_level/contamination/summary.csv")
+
+    include: cfg.subworkflow("contamination")
+    include: cfg.subworkflow("intensity_check")
+
+    sample_qc_targets.append("sample_level/contamination/summary.csv")
 
 
 if cfg.config.workflow_params.concordance_tools.king:
-    targets.append("sample_level/concordance/king.kin")
+    sample_qc_targets.append("sample_level/concordance/king.kin")
 
 if cfg.config.workflow_params.concordance_tools.graf:
-    targets.append("sample_level/concordance/graf.tsv")
+    sample_qc_targets.append("sample_level/concordance/graf.tsv")
 
 if cfg.config.workflow_params.concordance_tools.plink:
-    targets.extend(concordance_targets)
+    sample_qc_targets.extend(concordance_sample_qc_targets)
 
 
 rule all_sample_qc:
     input:
-        targets,
+        sample_qc_targets,
 
 
 ################################################################################

--- a/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
@@ -31,19 +31,22 @@ localrules:
 targets = [
     "sample_level/sample_qc.csv",
     "sample_level/snp_qc.csv",
-    "sample_level/concordance/KnownReplicates.csv",
-    "sample_level/concordance/InternalQcKnown.csv",
-    "sample_level/concordance/StudySampleKnown.csv",
-    "sample_level/concordance/UnknownReplicates.csv",
     "sample_level/summary_stats.txt",
     "sample_level/qc_failures/low_call_rate.txt",
     "sample_level/qc_failures/contaminated.txt",
     "sample_level/qc_failures/sex_discordant.txt",
-    "sample_level/qc_failures/replicate_discordant.txt",
     "sample_level/internal_controls.txt",
     "sample_level/call_rate.png",
     "sample_level/chrx_inbreeding.png",
     "sample_level/ancestry.png",
+]
+
+concordance_targets = [
+    "sample_level/concordance/KnownReplicates.csv",
+    "sample_level/concordance/InternalQcKnown.csv",
+    "sample_level/concordance/StudySampleKnown.csv",
+    "sample_level/concordance/UnknownReplicates.csv",
+    "sample_level/qc_failures/replicate_discordant.txt",
 ]
 
 if use_contamination:
@@ -55,6 +58,9 @@ if cfg.config.workflow_params.concordance_tools.king:
 
 if cfg.config.workflow_params.concordance_tools.graf:
     targets.append("sample_level/concordance/graf.tsv")
+
+if cfg.config.workflow_params.concordance_tools.plink:
+    targets.extend(concordance_targets)
 
 
 rule all_sample_qc:
@@ -597,6 +603,13 @@ def _intensity(wildcards):
     return []
 
 
+def _concordance_check(wildcards):
+    if cfg.config.workflow_params.concordance_tools.plink:
+        return "sample_level/concordance/summary.csv"
+    else:
+        return []
+
+
 rule sample_qc_table:
     input:
         sample_sheet_csv="cgr_sample_sheet.csv",
@@ -605,12 +618,13 @@ rule sample_qc_table:
         imiss_cr2=rules.plink_call_rate_post2.output.imiss,
         sexcheck_cr1=rules.sample_level_sexcheck.output[0],
         ancestry=rules.grafpop_ancestry.output[0],
-        sample_concordance_csv=rules.sample_concordance_summary.output[0],
+        sample_concordance_csv=_concordance_check,
         contam=_contam,
         intensity=_intensity,
     params:
         remove_contam=cfg.config.workflow_params.remove_contam,
         remove_rep_discordant=cfg.config.workflow_params.remove_rep_discordant,
+        concordance_checked=cfg.config.workflow_params.concordance_tools.plink,
     output:
         "sample_level/sample_qc.csv",
     script:

--- a/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/subject_qc.smk
@@ -36,7 +36,7 @@ wildcard_constraints:
 ################################################################################
 # Subject QC Targets
 ################################################################################
-targets = [
+subjectqc_targets = [
     "subject_level/subject_qc.csv",
     "subject_level/samples.bed",
     "subject_level/samples.bim",
@@ -55,7 +55,7 @@ targets = [
 
 rule all_subject_qc:
     input:
-        targets,
+        subjectqc_targets,
 
 
 ################################################################################


### PR DESCRIPTION
This PR adds a `concordance_tools`  option in in workflow_prams to control whether graf and king concordance checks should be executed (see 32280d45c401d96708e98362f56f2016a99562d6):

1. If `workflow_prams.concordance_tools.graf` is False, rules `graf_extract_fingerprint_snps`  and `sample_concordance_graf` will be skipped from execution in sample_qc.
2. If `workflow_prams.concordance_tools.king` is False, rule `sample_concordance_king` will be skipped from execution in sample_qc.

The output of above rules were not used by `sample_concordance.py` after PR https://github.com/NCI-CGR/GwasQcPipeline/pull/310 so graf and king file are removed from rule `sample_concordance_summary` as inputs to reflect that.

No changes in QC report. The output of these rules are currently for reference purpose only. Not used by any rules downstream.




resolves #364 .