### PR TITLE
actions: Update workflow to use miniconda action

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'noci') && startsWith(github.event.head_commit.message, 'docs')"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -51,21 +51,19 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'noci') && !startsWith(github.event.head_commit.message, 'docs')"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: "recursive"
-    - name: setup-conda
-      uses: s-weigand/setup-conda@v1
+
+    - name: Setup Conda
+      uses: conda-incubator/setup-miniconda@v2
       with:
-        # Whether to activate the conda base env (Default: 'true')
-        activate-conda: true
-        # If conda should be updated before running other commands (Default: 'false')
-        update-conda: true
-        # Python version which should be installed with conda (default: 'Default')
-        python-version: 3.8
-        # Additional channels like 'conda-forge' which can be used to install packages
-        conda-channels: conda-forge, bioconda, default
-    - name: Install dependencies
+        miniconda-version: "latest"
+        auto-update-conda: true
+        python-version: 3.8 
+        channels: conda-forge,bioconda,default
+
+    - name: Install Dependencies
       shell: bash
       run: |
         conda install -y mamba

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,23 +56,24 @@ jobs:
         submodules: "recursive"
 
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         miniconda-version: "latest"
-        auto-update-conda: true
+        mamba-version: "*"
         python-version: 3.8 
+        auto-update-conda: true
         channels: conda-forge,bioconda,default
 
     - name: Install Dependencies
-      shell: bash
+      shell: bash -l {0}
       run: |
-        conda install -y mamba
         python -m pip install --upgrade pip
         python -m pip install poetry
         poetry env info
         poetry install
+
     - name: Lint with flake8
-      shell: bash
+      shell: bash -l {0}
       run: |
         # stop the build if there are Python syntax errors or undefined names
         poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -80,13 +81,13 @@ jobs:
         poetry run flake8 . --count --exit-zero --statistics
 
     - name: Run black --check --exclude=tests/data .
-      shell: bash
+      shell: bash -l {0}
       run: |
         poetry run black --check --exclude=tests/data .
-
+      
     - name: If needed, commit black changes to the pull request
       if: failure()
-      shell: bash
+      shell: bash -l {0}
       run: |
         poetry run black --exclude=tests/data .
         git config --global user.name 'autoblack'
@@ -95,8 +96,9 @@ jobs:
         git checkout $GITHUB_HEAD_REF
         git commit -am "fixup: Format Python code with Black"
         git push
-
+    
     - name: Test with pytest
-      shell: bash
+      shell: bash -l {0}
       run: |
         poetry run pytest
+


### PR DESCRIPTION
**What**
Use [setup-miniconda](https://github.com/conda-incubator/setup-miniconda) GitHub action in place of existing action s-weigand/setup-conda@v1

**Why**
Our GitHub actions workflow began to fail at the setup-conda job, thus we decided to switch to the more maintained action. This job passed successfully when we did some local testing with [act](https://github.com/nektos/act).