### PR TITLE
Scalability_fixes

### DIFF
--- a/src/cgr_gwas_qc/cli/submit.py
+++ b/src/cgr_gwas_qc/cli/submit.py
@@ -164,6 +164,9 @@ def main(
     if sample_size < 1_000:  # need less walltime for smaller sample size
         payload["time_hr"] = 8
 
+    if sample_size > 50_000:
+        payload["local_mem_mb"] = 100000  # need more memory for larger sample size
+
     if cgems:
         payload["profile"] = get_profile("cgems")
         payload["queue"] = queue or ("all.q" if time_hr <= 24 else "long.q")

--- a/src/cgr_gwas_qc/cli/submit.py
+++ b/src/cgr_gwas_qc/cli/submit.py
@@ -80,7 +80,7 @@ def main(
         "Ignored if using `--cgems`.",
     ),
     cores: int = typer.Option(
-        8,
+        None,
         help="The maximum number of threads a rule can request. If pipeline is executed in `cluster_mode`, this will scale down the threads to `cores`.",
     ),
 ):

--- a/src/cgr_gwas_qc/cluster_profiles/ccad2/config.yaml
+++ b/src/cgr_gwas_qc/cluster_profiles/ccad2/config.yaml
@@ -10,5 +10,5 @@ printshellcmds: true
 rerun-incomplete: true
 restart-times: 3
 use-conda: true
-cores: &cores 44
+cores: &cores 20
 max-threads: *cores

--- a/src/cgr_gwas_qc/cluster_profiles/ccad2/submit.py
+++ b/src/cgr_gwas_qc/cluster_profiles/ccad2/submit.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import grp
 from dataclasses import dataclass, field
-from datetime import timedelta
 from typing import Set
 
 from snakemake.utils import read_job_properties
@@ -41,8 +40,9 @@ class Ccad2Options(ClusterOptions):
             " --parsable"
         )
 
-        if self.time > timedelta(hours=4):
-            self.queue.discard("defq")
+        # see issue #386
+        # if self.time > timedelta(hours=4):
+        #    self.queue.discard("defq")
 
         formatted_time = f"{self.time.days}-{self.time.seconds // 3600}"  # days-hours for slurm
 

--- a/src/cgr_gwas_qc/workflow/conda/bio2zarr.yml
+++ b/src/cgr_gwas_qc/workflow/conda/bio2zarr.yml
@@ -1,0 +1,10 @@
+channels:
+  - bioconda
+dependencies:
+  - verifyidintensity=0.0.1
+  - python>=3.9
+  - pysam
+  - pip
+  - pip:
+    - bio2zarr==0.1.4
+    - sgkit==0.9.0

--- a/src/cgr_gwas_qc/workflow/modules/bcf.smk
+++ b/src/cgr_gwas_qc/workflow/modules/bcf.smk
@@ -43,7 +43,10 @@ rule convert_bcf_to_plink_bed:
     threads: workflow.cores
     resources:
         mem_mb=ceil((0.07 * len(cfg.ss))) + 1024,
-        time_hr=ceil((0.22 * len(cfg.ss)) + (9e-4 * cfg.config.num_snps) / 3600),
+        time_hr=lambda wc, attempt: ceil(
+            ((0.22 * len(cfg.ss)) + (9e-4 * cfg.config.num_snps)) / 3600
+        )
+        * attempt,
     shell:
         "plink2 --allow-extra-chr 0 --keep-allele-order --double-id --bcf {input.bcf} --vcf-filter --update-sex {params.unknown_sex} --output-chr 26 --split-par hg38 --make-pgen --out sample_level/bcf2plink  --memory {resources.mem_mb} --threads {threads} ;"
         "plink2 --pfile sample_level/bcf2plink --make-pgen --sort-vars --out sample_level/bcf2plink-sorted --threads {threads} --memory {resources.mem_mb}  ;"
@@ -103,7 +106,9 @@ rule gtc_to_bcf:
     conda:
         cfg.conda("bcftools")
     resources:
-        time_hr=ceil(((len(cfg.ss) + 1) * (cfg.config.num_snps * 3e-6)) / 3600) + 1,
+        time_hr=lambda wc, attempt: ceil(((len(cfg.ss) + 1) * (cfg.config.num_snps * 3e-6)) / 3600)
+        * attempt
+        + 1,
         mem_mb=ceil((len(cfg.ss) * (cfg.config.num_snps * 1.06e-6)) + (cfg.config.num_snps * 2e-3))
         + 200,
     shell:
@@ -122,3 +127,29 @@ rule symlink_bcf:
         "sample_level/samples.bcf",
     shell:
         "ln -s {input.bcf} {output}"
+
+
+rule bcf2zarr:
+    """Converts BCF to Zarr format"""
+    input:
+        bcf="sample_level/samples.bcf",
+    params:
+        variants_chunk_size=min(100000, cfg.config.num_snps),
+        samples_chunk_size=min(100, int(len(cfg.ss) / len(cfg.cluster_groups))),
+    output:
+        directory("sample_level/samples.zarr"),
+    conda:
+        cfg.conda("bio2zarr")
+    threads: 2
+    resources:
+        tmpdir="temp/",
+        mem_mb=lambda wildcards, attempt: max(
+            ceil(len(cfg.ss) * cfg.config.num_snps * 1e-6) + 300, 3000
+        )
+        * attempt,
+        time_hr=lambda wildcards, attempt: ceil(
+            (len(cfg.ss) * (cfg.config.num_snps * 3e-6)) / 3600
+        )
+        * attempt,
+    shell:
+        "vcf2zarr convert --variants-chunk-size {params.variants_chunk_size} --samples-chunk-size {params.samples_chunk_size} --worker-processes {threads} {input.bcf} {output}"

--- a/src/cgr_gwas_qc/workflow/modules/bcf.smk
+++ b/src/cgr_gwas_qc/workflow/modules/bcf.smk
@@ -43,7 +43,7 @@ rule convert_bcf_to_plink_bed:
     threads: workflow.cores
     resources:
         mem_mb=ceil((0.07 * len(cfg.ss))) + 1024,
-        time_hr=ceil((0.11 * len(cfg.ss)) / 3600),
+        time_hr=ceil((0.22 * len(cfg.ss)) + (9e-4 * cfg.config.num_snps) / 3600),
     shell:
         "plink2 --allow-extra-chr 0 --keep-allele-order --double-id --bcf {input.bcf} --vcf-filter --update-sex {params.unknown_sex} --output-chr 26 --split-par hg38 --make-pgen --out sample_level/bcf2plink  --memory {resources.mem_mb} --threads {threads} ;"
         "plink2 --pfile sample_level/bcf2plink --make-pgen --sort-vars --out sample_level/bcf2plink-sorted --threads {threads} --memory {resources.mem_mb}  ;"
@@ -109,7 +109,7 @@ rule gtc_to_bcf:
     shell:
         """
         bcftools +{params.gtc2vcf_location} --threads {threads} --gtcs {input.gtcs} --bpm {params.bpm} --fasta-ref {params.reference_fasta} {params.additional_params} -Ou | bcftools sort -Ou -T ./bcftools. | bcftools norm --no-version -Ou --check-ref x -f {params.reference_fasta} --multiallelics -any |
-        bcftools filter --exclude 'INFO/INTENSITY_ONLY=1' --soft-filter 'int_only' -Ob --write-index --output {output.bcf}
+        bcftools filter --exclude 'REF==ALT|INFO/INTENSITY_ONLY=1' --soft-filter 'int_only' -Ob --write-index --output {output.bcf}
         """
 
 

--- a/src/cgr_gwas_qc/workflow/modules/idat.smk
+++ b/src/cgr_gwas_qc/workflow/modules/idat.smk
@@ -46,6 +46,9 @@ rule idat2gtc:
     threads: workflow.cores
     envmodules:
         "dragena/1.0.0",
+    resources:
+        mem_mb=lambda wildcards, attempt: 1024 * 8 * attempt,
+        time_hr=lambda wildcards, attempt: 5 * attempt,
     shell:
         """
         if [ "{params.dragena_location}" != "None" ];then dragena='{params.dragena_location}';else  dragena='dragena';fi
@@ -87,5 +90,5 @@ rule check_gtc_creation:
             barcode not in gtcList
             for barcode in cfg.expand("{SentrixBarcode_A}_{SentrixPosition_A}")
         )
-        cfg.ss.to_csv("cgr_sample_sheet.csv")
+        cfg.ss.to_csv("cgr_sample_sheet.csv", index=False)
         Path("sample_level/gtcs_check.done").touch()

--- a/src/cgr_gwas_qc/workflow/modules/idat.smk
+++ b/src/cgr_gwas_qc/workflow/modules/idat.smk
@@ -47,7 +47,7 @@ rule idat2gtc:
     envmodules:
         "dragena/1.0.0",
     resources:
-        mem_mb=lambda wildcards, attempt: 1024 * 8 * attempt,
+        mem_mb=lambda wildcards, attempt: 1024 * 100 * attempt,
         time_hr=lambda wildcards, attempt: 5 * attempt,
     shell:
         """

--- a/src/cgr_gwas_qc/workflow/modules/plink.smk
+++ b/src/cgr_gwas_qc/workflow/modules/plink.smk
@@ -528,7 +528,7 @@ rule genome:
     threads: workflow.cores
     resources:
         mem_mb=lambda wildcards, attempt: attempt * 16000,
-        time_hr=lambda wildcards, attempt: attempt * 3,
+        time_hr=lambda wildcards, attempt: attempt * 6,
     conda:
         cfg.conda("plink2")
     shell:

--- a/src/cgr_gwas_qc/workflow/modules/thousand_genomes.smk
+++ b/src/cgr_gwas_qc/workflow/modules/thousand_genomes.smk
@@ -49,6 +49,9 @@ rule pull_b_allele_freq_from_1kg_bcfinput:
             cfg.config.snp_array,
             cfg.config.software_params.contam_population,
         ),
+    resources:
+        mem_mb=2000,
+        time_hr=lambda wildcards, attempt: 2 * attempt,
     script:
         "../scripts/vcf2abf.py"
 

--- a/src/cgr_gwas_qc/workflow/scripts/grouped_contamination.py
+++ b/src/cgr_gwas_qc/workflow/scripts/grouped_contamination.py
@@ -39,7 +39,7 @@ def main(
     threads: int = typer.Argument(8, help="number of threads"),
 ):
     ss = sample_sheet.read(sample_sheet_csv).query(
-        f"cluster_group == '{grp}'&is_missing_gtc==False"
+        f"cluster_group == '{grp}'&is_missing_gtc==False&is_missing_idats==False"
     )
 
     # Make temp folders

--- a/src/cgr_gwas_qc/workflow/scripts/grouped_intensity_from_vcf.py
+++ b/src/cgr_gwas_qc/workflow/scripts/grouped_intensity_from_vcf.py
@@ -26,7 +26,7 @@ def main(
     threads: int = 8,
 ):
     ss = sample_sheet.read(sample_sheet_csv).query(
-        f"cluster_group == '{grp}'&is_missing_gtc==False"
+        f"cluster_group == '{grp}'&is_missing_gtc==False&is_missing_idats==False"
     )
     tmp_dir = Path(outfile).parent / "temp_median_idat"
     tmp_dir.mkdir(exist_ok=True, parents=True)

--- a/src/cgr_gwas_qc/workflow/scripts/grouped_intensity_from_vcf.py
+++ b/src/cgr_gwas_qc/workflow/scripts/grouped_intensity_from_vcf.py
@@ -22,7 +22,9 @@ def main(
     notemp: bool = False,
     threads: int = 8,
 ):
-    ss = sample_sheet.read(sample_sheet_csv).query(f"cluster_group == '{grp}'")
+    ss = sample_sheet.read(sample_sheet_csv).query(
+        f"cluster_group == '{grp}'&is_missing_gtc==False"
+    )
     tmp_dir = Path(outfile).parent / "temp_median_idat"
     tmp_dir.mkdir(exist_ok=True, parents=True)
 

--- a/src/cgr_gwas_qc/workflow/scripts/grouped_intensity_from_vcf.py
+++ b/src/cgr_gwas_qc/workflow/scripts/grouped_intensity_from_vcf.py
@@ -7,18 +7,21 @@ from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from typing import List
 
+import typer
 from snakemake.rules import expand
 
 from cgr_gwas_qc.parsers import sample_sheet
-from cgr_gwas_qc.typing import PathLike
 from cgr_gwas_qc.workflow.scripts import agg_median_idat_intensity, median_intensity_from_vcf
 
+app = typer.Typer(add_completion=False)
 
+
+@app.command()
 def main(
-    vcf_file: PathLike,
-    sample_sheet_csv: PathLike,
+    vcf_file: Path,
+    sample_sheet_csv: Path,
     grp: str,
-    outfile: PathLike,
+    outfile: Path,
     notemp: bool = False,
     threads: int = 8,
 ):
@@ -58,10 +61,13 @@ def calculate_median_intensity_from_vcf(ss, vcf_file, outdir, threads) -> List[P
     return outfiles
 
 
-if __name__ == "__main__" and "snakemake" in locals():
-    main(
-        **{k: v for k, v in snakemake.input.items()},  # type: ignore # noqa
-        **{k: v for k, v in snakemake.params.items()},  # type: ignore # noqa
-        outfile=snakemake.output[0],  # type: ignore # noqa
-        threads=snakemake.threads or 2,  # type: ignore # noqa
-    )
+if __name__ == "__main__":
+    if "snakemake" in locals():
+        main(
+            **{k: v for k, v in snakemake.input.items()},  # type: ignore # noqa
+            **{k: v for k, v in snakemake.params.items()},  # type: ignore # noqa
+            outfile=snakemake.output[0],  # type: ignore # noqa
+            threads=snakemake.threads or 2,  # type: ignore # noqa
+        )
+    else:
+        app()

--- a/src/cgr_gwas_qc/workflow/scripts/median_intensity_from_zarr.py
+++ b/src/cgr_gwas_qc/workflow/scripts/median_intensity_from_zarr.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+import numpy as np
+import sgkit as sg
+import typer
+import xarray as xr
+from dask.distributed import Client
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def main(
+    zarr_ds: Path = typer.Argument(
+        ...,
+        help="Path to a multisample zarr dataset converted from VCF/BCF file.",
+        exists=True,
+        readable=True,
+    ),
+    outfile: Path = typer.Argument(
+        ...,
+        help="Path to output file to write sample median intensities.",
+        file_okay=True,
+        writable=True,
+    ),
+    threads: int = typer.Argument(
+        1,
+        help="Number of CPU threads to use.",
+    ),
+) -> None:
+
+    Client(n_workers=threads, threads_per_worker=1)
+    z = sg.load_dataset(zarr_ds, storage_options={"mode": "r"})
+    z["call_X"] = z.call_X.astype(np.uint16)
+    z["call_Y"] = z.call_Y.astype(np.uint16)
+    z = z.assign(xy_sum=z.call_X + z.call_Y)
+    median_intensities = np.empty(
+        z.sample_id.shape, dtype=[("Sample_ID", np.object_), ("median_intensity", np.float16)]
+    )
+    median_intensities["Sample_ID"] = z.sample_id
+    median_intensities["median_intensity"] = (
+        xr.DataArray.median(z.call_X + z.call_Y, dim="variants").compute().values
+    )
+    np.savetxt(
+        outfile,
+        median_intensities,
+        fmt=["%s", "%.1f"],
+        delimiter=",",
+        header="Sample_ID,median_intensity",
+        comments="",
+    )
+
+
+if __name__ == "__main__":
+    if "snakemake" in locals():
+        main(
+            **{k: v for k, v in snakemake.input.items() if not k.startswith("_")},  # type: ignore # noqa
+            outfile=snakemake.output[0],  # type: ignore # noqa
+            threads=snakemake.threads,  # type: ignore # noqa
+        )
+    else:
+        app()

--- a/src/cgr_gwas_qc/workflow/scripts/sample_concordance.py
+++ b/src/cgr_gwas_qc/workflow/scripts/sample_concordance.py
@@ -59,7 +59,7 @@ DTYPES = {
 }
 
 
-def read(filename: PathLike):
+def read(filename: PathLike, **kwargs) -> pd.DataFrame:
     """Read the sample concordance table
 
     Returns:
@@ -80,7 +80,7 @@ def read(filename: PathLike):
         - PLINK_is_ge_pi_hat
         - PLINK_is_ge_concordance
     """
-    return pd.read_csv(filename, dtype=DTYPES)
+    return pd.read_csv(filename, dtype=DTYPES, **kwargs)
 
 
 @app.command()

--- a/src/cgr_gwas_qc/workflow/scripts/split_sample_concordance.py
+++ b/src/cgr_gwas_qc/workflow/scripts/split_sample_concordance.py
@@ -161,6 +161,20 @@ def read_unknown_sample_concordance(filename: PathLike) -> pd.DataFrame:
     return pd.read_csv(filename, dtype=UNKNOWN_DTYPES)
 
 
+def get_row_indices_where_true(
+    sample_concordance_csv: pd.DataFrame,
+    col_name: str,
+) -> list:
+    """Get the row indices of the concordance table where a Boolean column is True. This can be used to skip rows."""
+    # Prepare list of indicies to be skipped where is_expected_replicate is False.
+    bool_column = sample_concordance.read(sample_concordance_csv, usecols=[col_name], engine="c")[
+        col_name
+    ]
+    bool_column = bool_column[~bool_column].index
+    bool_column += 1
+    return bool_column.tolist()
+
+
 @app.command()
 def main(
     sample_concordance_csv: Path,
@@ -169,12 +183,18 @@ def main(
     known_study_csv: Path,
     unknown_csv: Path,
 ):
-    # Load sample level concordance information
-    concordance = sample_concordance.read(sample_concordance_csv)
+    # Prepare list of indicies to be skipped where is_expected_replicate is False.
+    is_expected_replicate = get_row_indices_where_true(
+        sample_concordance_csv, "is_expected_replicate"
+    )
 
+    # Load sample level concordance information
+    # skip rows where is_expected_replicate is False
     # Save Known Replicates
-    known_df = concordance.query("is_expected_replicate").rename(
-        {"Subject_ID1": "Subject_ID"}, axis=1
+    known_df = (
+        sample_concordance.read(sample_concordance_csv, skiprows=is_expected_replicate, engine="c")
+        .query("is_expected_replicate")
+        .rename({"Subject_ID1": "Subject_ID"}, axis=1)
     )
     known_df.reindex(KNOWN_DTYPES, axis=1).to_csv(known_csv, index=False)
 
@@ -189,8 +209,13 @@ def main(
     ).to_csv(known_study_csv, index=False)
 
     # Save Unexpected Replicates
+    is_unexpected_replicate = get_row_indices_where_true(
+        sample_concordance_csv, "is_unexpected_replicate"
+    )
     (
-        concordance.query("is_unexpected_replicate")
+        sample_concordance.read(
+            sample_concordance_csv, skiprows=is_unexpected_replicate, engine="c"
+        )
         .reindex(UNKNOWN_DTYPES, axis=1)
         .to_csv(unknown_csv, index=False)
     )

--- a/src/cgr_gwas_qc/workflow/scripts/vcf2abf.py
+++ b/src/cgr_gwas_qc/workflow/scripts/vcf2abf.py
@@ -14,7 +14,14 @@ app = typer.Typer(add_completion=False)
 
 
 def is_biallelic_snp(rec):
-    return len(rec.ref) == 1 and len(rec.alts[0]) == 1
+    return len(rec.ref) == 1 and len(get_first_alt(rec)) == 1
+
+
+def get_first_alt(rec):
+    if rec.alts is not None:
+        return rec.alts[0]
+    else:
+        return str(None)
 
 
 @app.command()
@@ -56,7 +63,7 @@ def main(
                 rec.chrom,
                 rec.pos,
                 rec.ref[0],
-                rec.alts[0],
+                get_first_alt(rec),
                 is_biallelic_snp(rec),
                 # rec.info["IGC"],
                 rec.info["ALLELE_A"],

--- a/src/cgr_gwas_qc/workflow/scripts/zarr_contamination.py
+++ b/src/cgr_gwas_qc/workflow/scripts/zarr_contamination.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+import concurrent.futures
+import subprocess as sp
+import tempfile
+from functools import partial
+from io import StringIO
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import sgkit as sg
+import typer
+from dask.distributed import Client
+from numba import njit
+
+app = typer.Typer(add_completion=True)
+
+
+@app.command()
+def main(
+    zarr_ds: Path = typer.Option(
+        ...,
+        help="Path to a multisample zarr dataset converted from VCF/BCF file.",
+        exists=True,
+        readable=True,
+    ),
+    outfile: Path = typer.Option(
+        ...,
+        help="Path to output file to write ADPC.bin intensities.",
+        file_okay=True,
+        writable=True,
+    ),
+    abf: Optional[Path] = typer.Option(
+        None,
+        help="Path to abf.txt file containing B-allele frequencies. If None, conamianation check will be performed without it.",
+        exists=True,
+        readable=True,
+    ),
+    adpc: Optional[Path] = typer.Option(
+        None,
+        help="Path to output ADPC.bin file. If None, a temporary file will be created.",
+        exists=True,
+        readable=True,
+    ),
+    batch_size: int = typer.Option(
+        100,
+        help="Number of samples to process in a batch. More samples per batch will use more memory.",
+    ),
+    threads: int = typer.Argument(
+        1,
+        help="Number of threads to use for parallel processing.",
+    ),
+) -> None:
+
+    def check_verifyidintensity(adpc: Path, n_markers: int, sampleidx: int, abf: Path = None):
+        """Checks contamination for a single sample from a multisample ADPC.bin file using verifyIDintensity tool.
+        Parameters
+        ----------
+        adpc : Path
+            Path to ADPC.bin file.
+        n_markers : int
+            Number of markers in the ADPC.bin file.
+        sampleidx : int
+            Index of the sample to check for contamination.
+        abf : Path
+            Path to abf.txt file containing B-allele frequencies. If None, conamianation check will be performed without it.
+        Returns
+        -------
+        pd.DataFrame
+            Contamination check results.
+        """
+        s_blocksize = 18 * n_markers
+        skip = 16 + s_blocksize * sampleidx
+        with tempfile.NamedTemporaryFile(delete=True) as temp_sample_adpc:
+            cmd_add_header = f"dd skip=0 count=16 iflag=skip_bytes,count_bytes if={adpc} > {temp_sample_adpc.name}"
+            cmd_retrieve_sample = f"dd skip={skip} count={s_blocksize} iflag=skip_bytes,count_bytes if={adpc} >> {temp_sample_adpc.name}"
+            if abf is not None:
+                cmd_verifyidintensity_check = f"verifyIDintensity -n 1 -v -p -m {n_markers} -i {temp_sample_adpc.name} -b {abf}"
+                rows_to_skip = [0, 1, 3]
+            else:
+                cmd_verifyidintensity_check = (
+                    f"verifyIDintensity -n 1 -v -p -m {n_markers} -i {temp_sample_adpc.name}"
+                )
+                rows_to_skip = [1]
+            cmd = cmd_add_header + ";" + cmd_retrieve_sample + ";" + cmd_verifyidintensity_check
+            contam_out = sp.run(cmd, shell=True, capture_output=True, text=True, check=True)
+            return pd.read_csv(StringIO(contam_out.stdout), sep="\\s+", skiprows=rows_to_skip)
+
+    def zarr2adpc(zarr_ds: Path, adpc: Path, batch_size: int, threads: int):
+        """Converts a multisample zarr dataset to ADPC.bin file.
+        Parameters
+        ----------
+        zarr_ds : Path
+            Path to a multisample zarr dataset converted from VCF/BCF file.
+        adpc : Path
+            Path to output ADPC.bin file.
+        batch_size : int
+            Number of samples to process in a batch.
+        threads : int
+            Number of threads to use for parallel processing.
+        Returns
+        -------
+        Path
+            Path to ADPC.bin file.
+        np.ndarray
+            Sample IDs.
+        int
+            Number of markers in the ADPC.bin file.
+        """
+
+        def get_illumina_genotype(allele_a, allele_b, vcf_gt):
+            illumina_genotype = np.full(vcf_gt.shape[0], 3, dtype=np.uint16)
+            for v in np.ndindex(illumina_genotype.shape[0]):
+                if vcf_gt[v][0] != vcf_gt[v][1]:
+                    illumina_genotype[v] = 1
+                elif vcf_gt[v][0] == vcf_gt[v][1] == allele_a[v]:
+                    illumina_genotype[v] = 0
+                elif vcf_gt[v][0] == vcf_gt[v][1] == allele_b[v]:
+                    illumina_genotype[v] = 2
+            return illumina_genotype
+
+        def get_illumina_genotype_multisample(allele_a, allele_b, vcf_gt):
+            illumina_genotype = np.full(vcf_gt.shape[:2], 3, dtype=np.uint16)
+            for s in np.ndindex(illumina_genotype.shape[1]):
+                for v in np.ndindex(illumina_genotype.shape[0]):
+                    if vcf_gt[v][s][0] != vcf_gt[v][s][1]:
+                        illumina_genotype[v][s] = 1
+                    elif vcf_gt[v][s][0] == vcf_gt[v][s][1] == allele_a[v]:
+                        illumina_genotype[v][s] = 0
+                    elif vcf_gt[v][s][0] == vcf_gt[v][s][1] == allele_b[v]:
+                        illumina_genotype[v][s] = 2
+            return illumina_genotype
+
+        record_struct = {
+            "X": "<H",
+            "Y": "<H",
+            "NORMX": "<f",
+            "NORMY": "<f",
+            "IGC": "<f",
+            "illumina_GT": "<H",
+        }
+        Path(adpc).parent.mkdir(parents=True, exist_ok=True)
+        with open(adpc, "wb") as f:
+            f.write(np.repeat(0, 8).astype("<H").tobytes())
+        Client(n_workers=threads, threads_per_worker=1)
+        variables = [
+            "call_X",
+            "call_Y",
+            "call_NORMX",
+            "call_NORMY",
+            "call_IGC",
+            "variant_ALLELE_A",
+            "variant_ALLELE_B",
+            "call_genotype",
+        ]
+        z = sg.load_dataset(zarr_ds, storage_options={"mode": "r"})
+        sample_ids = z.sample_id.to_numpy()
+        n_markers = z.variants.shape[0]
+        z["call_X"] = z.call_X.astype(np.uint16)
+        z["call_Y"] = z.call_Y.astype(np.uint16)
+        z["variant_ALLELE_A"] = z.variant_ALLELE_A.astype(np.int8)
+        z["variant_ALLELE_B"] = z.variant_ALLELE_B.astype(np.int8)
+        z = z[variables]
+        with open(adpc, "ab") as f:
+            for i in range(0, z.samples.shape[0], batch_size):
+                z_batch = z.isel(samples=slice(i, i + batch_size))
+                z_batch["call_illumina_genotype"] = (
+                    ("variants", "samples"),
+                    njit(get_illumina_genotype_multisample, parallel=False)(
+                        z_batch.variant_ALLELE_A.values,
+                        z_batch.variant_ALLELE_B.values,
+                        z_batch.call_genotype.values,
+                    ),
+                )
+                z_batch = z_batch.drop_vars(
+                    ["call_genotype", "variant_ALLELE_A", "variant_ALLELE_B"]
+                )
+                z_batch = z_batch.load()
+                z_batch["call_NORMX"] = (
+                    ("variants", "samples"),
+                    np.nan_to_num(z_batch.call_NORMX, posinf=0, neginf=0, copy=False),
+                )
+                z_batch["call_NORMY"] = (
+                    ("variants", "samples"),
+                    np.nan_to_num(z_batch.call_NORMY, posinf=0, neginf=0, copy=False),
+                )
+                f.write(
+                    z_batch.to_dataframe()
+                    .sort_index(level=["samples", "variants"])
+                    .to_records(index=False, column_dtypes=record_struct)
+                    .tobytes()
+                )
+                f.flush()
+        return adpc, sample_ids, n_markers
+
+    if adpc is None:
+        adpc_temp = tempfile.NamedTemporaryFile(delete=False)
+        adpc = Path(adpc_temp.name)
+    adpc, sample_ids, n_markers = zarr2adpc(zarr_ds, adpc, batch_size, threads)
+    check_verifyidintensity = partial(check_verifyidintensity, adpc, n_markers, abf=abf)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
+        results = executor.map(check_verifyidintensity, range(0, sample_ids.shape[0]))
+    results = pd.concat(results).assign(ID=sample_ids).rename({"ID": "Sample_ID"}, axis=1)
+    results.to_csv(outfile, index=False)
+    if adpc_temp is None:
+        adpc_temp.unlink()
+
+
+if __name__ == "__main__":
+    if "snakemake" in locals():
+        defaults = {}
+        defaults.update({k: Path(v) for k, v in snakemake.input.items()})  # type: ignore # noqa
+        defaults.update({k: v for k, v in snakemake.params.items()})  # type: ignore # noqa
+        defaults.update({"outfile": Path(snakemake.output[0])})  # type: ignore # noqa
+        defaults.update({"threads": snakemake.threads})  # type: ignore # noqa
+        main(**defaults)
+    else:
+        app()

--- a/src/cgr_gwas_qc/workflow/sub_workflows/contamination.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/contamination.smk
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from cgr_gwas_qc import load_config
+from math import ceil
 
 cfg = load_config()
 
@@ -30,10 +31,19 @@ module thousand_genomes:
 
 if cfg.config.user_files.bcf or cfg.config.workflow_params.convert_gtc2bcf:
 
-    use rule pull_b_allele_freq_from_1kg_bcfinput from thousand_genomes as pull_b_allele_freq_from_1kg with:
-        input:
-            bcf_file="sample_level/samples.bcf",
-            kgvcf_file=cfg.config.reference_files.thousand_genome_vcf,
+    if config.get("cluster_mode", False) and len(cfg.cluster_groups) > 2:
+
+        use rule pull_b_allele_freq_from_1kg_bcfinput from thousand_genomes as pull_b_allele_freq_from_1kg with:
+            input:
+                bcf_file=expand("sample_level/{grp}/samples.bcf", grp=cfg.cluster_groups)[0],
+                kgvcf_file=cfg.config.reference_files.thousand_genome_vcf,
+
+    else:
+
+        use rule pull_b_allele_freq_from_1kg_bcfinput from thousand_genomes as pull_b_allele_freq_from_1kg with:
+            input:
+                bcf_file="sample_level/samples.bcf",
+                kgvcf_file=cfg.config.reference_files.thousand_genome_vcf,
 
 else:
 
@@ -67,53 +77,37 @@ rule verifyidintensity_conda:
 ################################################################################
 # If BCF file is input
 if cfg.config.user_files.bcf or cfg.config.workflow_params.convert_gtc2bcf:
-    if config.get("cluster_mode", False):
+    if config.get("cluster_mode", False) and len(cfg.cluster_groups) > 2:
 
         localrules:
             agg_verifyidintensity,
 
         rule grouped_contamination:
-            """Extracts normalized intensities and other metrics from an aggregated
-            BCF file and writes to Illumina ADPC.BIN per sample.
-
-            This is the format required by ``verifyIDintensity``. The script also
-            runs some sanity checks (intensities and normalized intensities > 0;
-            genotypes are one of {0, 1, 2, 3}) while processing each file.
-
-            .. warning::
-                This is a submission hot spot creating 1 job per sample.
-
-            Find contaminated samples using allele intensities.
-
-            Uses ``verifyIDintensity`` to find samples with allele intensities that deviate from the
-            population.
-
-            .. warning::
-                This is a submission hot spot creating 1 job per sample.
-
-            .. note::
-                Here we are running ``verifyIDintensity`` in single sample mode. This software also has a
-                multi-sample mode which may be faster and give better estimates. The problem with
-                multi-sample mode is that it only works when you have a "large" number of samples.
-            """
             input:
-                sample_sheet_csv="cgr_sample_sheet.csv",
-                bcf_file="sample_level/{grp}/samples.bcf",
-                abf_file=rules.pull_b_allele_freq_from_1kg.output.abf_file,
-                _=rules.verifyidintensity_conda.output[0],
+                zarr_ds="sample_level/{grp}/samples.zarr",
+                abf=rules.pull_b_allele_freq_from_1kg.output.abf_file,
             params:
-                grp="{grp}",
-                snps=cfg.config.num_snps,
-                conda_env=cfg.conda("verifyidintensity"),
-                notemp=config.get("notemp", False),
+                adpc=None,
+                batch_size=100,
+            conda:
+                cfg.conda("bio2zarr")
             output:
-                temp("sample_level/contamination/{grp}/verifyIDintensity.csv"),
-            threads: 12
+                outfile=temp("sample_level/contamination/{grp}/verifyIDintensity.csv"),
+            threads: 6
             resources:
-                mem_mb=lambda wildcards, attempt: 1024 * 12 * attempt,
-                time_hr=lambda wildcards, attempt: 4 * attempt,
+                mem_mb=lambda wildcards, attempt: (0.01 * cfg.config.num_snps)
+                + (0.03 * (cfg.config.num_samples / len(cfg.cluster_groups)))
+                + 1000 * attempt,
+                time_hr=lambda wildcards, attempt: ceil(
+                    (
+                        (0.0015 * cfg.config.num_snps)
+                        + (0.00088 * (cfg.config.num_samples / len(cfg.cluster_groups)))
+                    )
+                    / 3600
+                )
+                * attempt,
             script:
-                "../scripts/grouped_contamination.py"
+                "../scripts/zarr_contamination.py"
 
         rule agg_verifyidintensity:
             input:
@@ -128,66 +122,28 @@ if cfg.config.user_files.bcf or cfg.config.workflow_params.convert_gtc2bcf:
 
     else:
 
-        rule per_sample_vcf_to_adpc:
-            """From an aggregated BCF input file, extracts normalized intensities and
-            other metrics  for the target sample and writes to Illumina ADPC.BIN per sample.
-
-            This is the format required by ``verifyIDintensity``. The script also
-            runs some sanity checks (intensities and normalized intensities > 0;
-            genotypes are one of {0, 1, 2, 3}) while processing each file.
-
-            .. warning::
-                This is a submission hot spot creating 1 job per sample.
-            """
-            input:
-                bcf_file="sample_level/samples.bcf",
-            params:
-                target_sample="{Sample_ID}",
-            output:
-                temp("sample_level/per_sample_adpc/{Sample_ID}.adpc.bin"),
-            resources:
-                mem_mb=lambda wildcards, attempt: attempt * 1024,
-            script:
-                "../scripts/vcf2adpc.py"
-
-        rule per_sample_contamination_verifyIDintensity:
-            """Find contaminated samples using allele intensities.
-
-            Uses ``verifyIDintensity`` to find samples with allele intensities that deviate from the
-            population.
-
-            .. warning::
-                This is a submission hot spot creating 1 job per sample.
-
-            .. note::
-                Here we are running ``verifyIDintensity`` in single sample mode. This software also has a
-                multi-sample mode which may be faster and give better estimates. The problem with
-                multi-sample mode is that it only works when you have a "large" number of samples.
-            """
-            input:
-                adpc=rules.per_sample_vcf_to_adpc.output[0],
-                abf=rules.pull_b_allele_freq_from_1kg.output.abf_file,
-                _=rules.verifyidintensity_conda.output[0],
-            params:
-                snps=cfg.config.num_snps,
-                conda_env=cfg.conda("verifyidintensity"),
-            output:
-                temp("sample_level/per_sample_contamination_test/{Sample_ID}.contam.out"),
-            resources:
-                mem_mb=lambda wildcards, attempt: attempt * 1024,
-            script:
-                "../scripts/verifyidintensity.py"
-
         rule agg_verifyidintensity:
             input:
-                cfg.expand(rules.per_sample_contamination_verifyIDintensity.output[0]),
+                zarr_ds="sample_level/samples.zarr",
+                abf=rules.pull_b_allele_freq_from_1kg.output.abf_file,
+            params:
+                adpc=None,
+                batch_size=100,
+            conda:
+                cfg.conda("bio2zarr")
             output:
-                "sample_level/contamination/verifyIDintensity.csv",
+                outfile="sample_level/contamination/verifyIDintensity.csv",
             resources:
-                mem_gb=lambda wildcards, attempt: attempt * 4,
-                time_hr=lambda wildcards, attempt: attempt**2,
+                mem_mb=lambda wildcards, attempt: (0.01 * cfg.config.num_snps)
+                + (0.03 * cfg.config.num_samples)
+                + 2000 * attempt,
+                time_hr=lambda wildcards, attempt: ceil(
+                    ((0.0015 * cfg.config.num_snps) + (0.00088 * cfg.config.num_samples)) / 3600
+                )
+                * attempt,
+            threads: 6
             script:
-                "../scripts/agg_verifyidintensity.py"
+                "../scripts/zarr_contamination.py"
 
 else:
     if config.get("cluster_mode", False):

--- a/src/cgr_gwas_qc/workflow/sub_workflows/contamination.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/contamination.smk
@@ -98,7 +98,7 @@ if cfg.config.user_files.bcf or cfg.config.workflow_params.convert_gtc2bcf:
             """
             input:
                 sample_sheet_csv="cgr_sample_sheet.csv",
-                bcf_file="sample_level/samples.bcf",
+                bcf_file="sample_level/{grp}/samples.bcf",
                 abf_file=rules.pull_b_allele_freq_from_1kg.output.abf_file,
                 _=rules.verifyidintensity_conda.output[0],
             params:

--- a/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
@@ -27,6 +27,14 @@ entry_points_targets = [
     "sample_level/samples.fam",
 ]
 
+if cfg.config.workflow_params.convert_gtc2bcf:
+    if config.get("cluster_mode", False) and len(cfg.cluster_groups) > 2:
+        entry_points_targets.append(
+            expand("sample_level/{grp}/samples.zarr", grp=cfg.cluster_groups)
+        )
+    else:
+        entry_points_targets.append("sample_level/samples.zarr")
+
 
 rule all_entry_points:
     input:
@@ -295,9 +303,10 @@ if cfg.config.user_files.gtc_pattern or cfg.config.workflow_params.convert_idat2
                 benchmark:
                     "benchmarks/gtc_to_bcf.{grp}" + ".tsv"
                 resources:
-                    time_hr=lambda wc: ceil(
-                        ((_get_n_samples(wc) + 1) * (cfg.config.num_snps * 3e-6)) / 3600
+                    time_hr=lambda wc, attempt: ceil(
+                        ((_get_n_samples(wc) + 1) * (cfg.config.num_snps * 1e-5)) / 3600
                     )
+                    * attempt
                     + 1,
                     mem_mb=lambda wc: ceil(
                         (_get_n_samples(wc) * (cfg.config.num_snps * 1.06e-6))
@@ -306,6 +315,29 @@ if cfg.config.user_files.gtc_pattern or cfg.config.workflow_params.convert_idat2
                     + 200,
                 output:
                     bcf="sample_level/{grp}/samples.bcf",
+
+            use rule bcf2zarr from bcf_module with:
+                input:
+                    bcf="sample_level/{grp}/samples.bcf",
+                output:
+                    directory("sample_level/{grp}/samples.zarr"),
+                resources:
+                    tmpdir="temp/",
+                    mem_mb=lambda wildcards, attempt: max(
+                        ceil(
+                            (cfg.config.num_samples / len(cfg.cluster_groups))
+                            * (cfg.config.num_snps * 2e-6)
+                        )
+                        + 300,
+                        3000,
+                    )
+                    * attempt,
+                    time_hr=lambda wildcards, attempt: ceil(
+                        (cfg.config.num_samples / len(cfg.cluster_groups))
+                        * (cfg.config.num_snps * 6e-6)
+                        / 3600
+                    )
+                    * attempt,
 
             rule merge_gtc_to_bcf_batches:
                 """Merges grouped bcf files to single merged bcf"""
@@ -326,10 +358,11 @@ if cfg.config.user_files.gtc_pattern or cfg.config.workflow_params.convert_idat2
                     )
                 threads: workflow.cores
                 resources:
-                    time_hr=ceil((len(cfg.ss) * 0.4) / 3600 + 1),
+                    time_hr=lambda wildcards, attempt: ceil((len(cfg.ss) * 0.4) / 3600 + 1)
+                    * attempt,
                     mem_mb=len(cfg.cluster_groups) * 70,
                 shell:
-                    "bcftools merge --threads {threads} --merge none {input.bcf_batches} -Ob -o {output}"
+                    "bcftools merge --threads {threads} --merge none {input.bcf_batches} -Ob -o {output} --write-index"
 
             use rule convert_bcf_to_plink_bed from bcf_module with:
                 input:
@@ -351,6 +384,12 @@ if cfg.config.user_files.gtc_pattern or cfg.config.workflow_params.convert_idat2
                     gtcs=rules.write_gtc_pathlist.output[0],
                 output:
                     bcf="sample_level/samples.bcf",
+
+            use rule bcf2zarr from bcf_module with:
+                input:
+                    bcf=rules.gtc_to_bcf.output[0],
+                output:
+                    directory("sample_level/samples.zarr"),
 
             use rule convert_bcf_to_plink_bed from bcf_module with:
                 input:

--- a/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
@@ -326,7 +326,7 @@ if cfg.config.user_files.gtc_pattern or cfg.config.workflow_params.convert_idat2
                     )
                 threads: workflow.cores
                 resources:
-                    time_hr=ceil((len(cfg.ss) * 0.2) / 3600 + 1),
+                    time_hr=ceil((len(cfg.ss) * 0.4) / 3600 + 1),
                     mem_mb=len(cfg.cluster_groups) * 70,
                 shell:
                     "bcftools merge --threads {threads} --merge none {input.bcf_batches} -Ob -o {output}"

--- a/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
@@ -308,11 +308,14 @@ if cfg.config.user_files.gtc_pattern or cfg.config.workflow_params.convert_idat2
                     )
                     * attempt
                     + 1,
-                    mem_mb=lambda wc: ceil(
-                        (_get_n_samples(wc) * (cfg.config.num_snps * 1.06e-6))
-                        + (cfg.config.num_snps * 2e-3)
+                    mem_mb=lambda wc, attempt: (
+                        ceil(
+                            (_get_n_samples(wc) * (cfg.config.num_snps * 1.06e-6))
+                            + (cfg.config.num_snps * 2e-3)
+                        )
+                        + 200
                     )
-                    + 200,
+                    * attempt,
                 output:
                     bcf="sample_level/{grp}/samples.bcf",
 

--- a/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/entry_points.smk
@@ -284,6 +284,7 @@ if cfg.config.user_files.gtc_pattern or cfg.config.workflow_params.convert_idat2
 
                 use rule write_gtc_pathlist from bcf_module with:
                     params:
+                        pattern=lambda wc: cfg.config.user_files.gtc_pattern,
                         grp=cfg.cluster_groups,
                     output:
                         temp("sample_level/{grp}/gtc.tsv"),

--- a/src/cgr_gwas_qc/workflow/sub_workflows/intensity_check.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/intensity_check.smk
@@ -53,7 +53,7 @@ if cfg.config.user_files.bcf or cfg.config.workflow_params.convert_gtc2bcf:
             """Calculate median intensity from raw intensities using VCF/BCF input."""
             input:
                 sample_sheet_csv="cgr_sample_sheet.csv",
-                vcf_file="sample_level/samples.bcf",
+                vcf_file="sample_level/{grp}/samples.bcf",
             params:
                 grp="{grp}",
                 notemp=config.get("notemp", False),

--- a/src/cgr_gwas_qc/workflow/sub_workflows/intensity_check.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/intensity_check.smk
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from cgr_gwas_qc import load_config
+from math import ceil
 
 cfg = load_config()
 
@@ -29,6 +30,7 @@ rule all_intensity_check:
 # sure that the conda env exists.
 localrules:
     illuminaio_conda,
+    bio2zarr_conda,
 
 
 rule illuminaio_conda:
@@ -40,35 +42,58 @@ rule illuminaio_conda:
         "touch {output[0]}"
 
 
+rule bio2zarr_conda:
+    output:
+        temp(".bio2zarr_env_built"),
+    conda:
+        cfg.conda("bio2zarr")
+    shell:
+        "touch {output[0]}"
+
+
+################################################################################
+# Imports
+################################################################################
+module bcf_module:
+    snakefile:
+        cfg.modules("bcf")
+    config:
+        {}
+
+
 ################################################################################
 # Workflow Rules
 ################################################################################
 if cfg.config.user_files.bcf or cfg.config.workflow_params.convert_gtc2bcf:
-    if config.get("cluster_mode", False):
+    if config.get("cluster_mode", False) and len(cfg.cluster_groups) > 2:
 
         localrules:
             agg_median_idat_intensity,
 
-        rule grouped_median_intensity_from_vcf:
-            """Calculate median intensity from raw intensities using VCF/BCF input."""
+        rule grouped_median_intensity_from_zarr:
+            """Calculate median intensity from raw intensities using Zarr dataset."""
             input:
-                sample_sheet_csv="cgr_sample_sheet.csv",
-                vcf_file="sample_level/{grp}/samples.bcf",
-            params:
-                grp="{grp}",
-                notemp=config.get("notemp", False),
+                zarr_ds="sample_level/{grp}/samples.zarr",
             output:
                 temp("sample_level/contamination/{grp}/median_idat_intensity.csv"),
-            threads: 12
+            conda:
+                cfg.conda("bio2zarr")
+            threads: 2
             resources:
-                mem_mb=lambda wildcards, attempt: 1024 * 12 * attempt,
-                time_hr=lambda wildcards, attempt: 4 * attempt,
+                mem_mb=lambda wildcards, attempt: 9e-6
+                * cfg.config.num_snps
+                * (cfg.config.num_samples / len(cfg.cluster_groups))
+                * attempt,
+                time_hr=lambda wildcards, attempt: ceil(
+                    0.001 * (cfg.config.num_samples / len(cfg.cluster_groups)) / 3600
+                )
+                * attempt,
             script:
-                "../scripts/grouped_intensity_from_vcf.py"
+                "../scripts/median_intensity_from_zarr.py"
 
         rule agg_median_idat_intensity:
             input:
-                expand(rules.grouped_median_intensity_from_vcf.output[0], grp=cfg.cluster_groups),
+                expand(rules.grouped_median_intensity_from_zarr.output[0], grp=cfg.cluster_groups),
             params:
                 notemp=config.get("notemp", False),
             output:
@@ -81,29 +106,24 @@ if cfg.config.user_files.bcf or cfg.config.workflow_params.convert_gtc2bcf:
 
     else:
 
-        rule per_sample_median_intensity_from_vcf:
-            """Calculate median intensity from raw intensities using VCF/BCF input."""
-            input:
-                vcf_file="sample_level/samples.bcf",
-            params:
-                sample_id="{Sample_ID}",
-            output:
-                temp("sample_level/contamination/per_sample_median_idat_intensity/{Sample_ID}.csv"),
-            resources:
-                mem_mb=lambda wildcards, attempt: attempt * 1024,
-            script:
-                "../scripts/median_intensity_from_vcf.py"
-
         rule agg_median_idat_intensity:
+            """Calculate median intensity from raw intensities using Zarr dataset."""
             input:
-                cfg.expand(rules.per_sample_median_intensity_from_vcf.output[0]),
+                zarr_ds="sample_level/samples.zarr",
             output:
                 "sample_level/contamination/median_idat_intensity.csv",
+            conda:
+                cfg.conda("bio2zarr")
+            threads: 2
             resources:
-                mem_gb=lambda wildcards, attempt: attempt * 4,
-                time_hr=lambda wildcards, attempt: attempt**2,
+                mem_mb=lambda wildcards, attempt: 9e-6
+                * cfg.config.num_snps
+                * cfg.config.num_samples
+                * attempt,
+                time_hr=lambda wildcards, attempt: ceil((0.001 * cfg.config.num_samples / 3600))
+                * attempt,
             script:
-                "../scripts/agg_median_idat_intensity.py"
+                "../scripts/median_intensity_from_zarr.py"
 
 else:
     if config.get("cluster_mode", False):


### PR DESCRIPTION
Fixes the scalability of BCF contamination and intensity checks by shifting to Zarr format. Additional couple smaller fixes that improves time and memory allocations include:

- Fixes #386. Removes prior setup of not submitting >4hrs job to defq. (https://github.com/NCI-CGR/GwasQcPipeline/commit/db9b3e14648d28567cc41dbf7349610d27e78352)
- Fixes #385. Reduces workflow.cores to 20 for CCAD2.](https://github.com/NCI-CGR/GwasQcPipeline/commit/0f76e6aabbbf03dedad3393e6c156e9a6713e65f)
- Fixes #396. Increases the memory allocation for Dragena.(https://github.com/NCI-CGR/GwasQcPipeline/commit/744da99193fbb74184e6c56a1728af2773f8e8c3)
- Auto increases the time for main process based on sample size.
- Increases time allocation for rule genome (IBD step) in multiples of 6 for each attempt.
