### PR TITLE
Fixes #409 by isolating the subject-level markdown qc report in a cond env.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cgr_gwas_qc"
-version = "1.9.0-rc2"
+version = "1.9.0-rc3"
 description = "The CGR GWAS QC Pipeline"
 authors = [
     "Justin Fear <justin.fear@nih.gov>",

--- a/src/cgr_gwas_qc/workflow/conda/qc_report_markdown.yml
+++ b/src/cgr_gwas_qc/workflow/conda/qc_report_markdown.yml
@@ -1,0 +1,9 @@
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - setuptools
+  - pandas
+  - tabulate>=0.9.0
+  - jinja2
+  - typer

--- a/src/cgr_gwas_qc/workflow/sub_workflows/delivery.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/delivery.smk
@@ -258,6 +258,8 @@ rule qc_report:
         hwe_png_dir="subject_level/hwe_plots",
     output:
         "delivery/qc_report.md",
+    conda:
+        cfg.conda("qc_report_markdown")
     script:
         "../scripts/qc_report.py"
 


### PR DESCRIPTION
This pull request updates the QC report generation workflow to improve reproducibility and environment management by introducing a dedicated Conda environment for the QC report script. Additionally, it bumps the project version.

**Workflow and environment improvements:**

* Added a new Conda environment definition file (`qc_report_markdown.yml`) specifying required dependencies for the QC report script, including `python=3.9`, `pandas`, `tabulate`, `jinja2`, and `typer` to ensure consistent execution.
* Updated the `qc_report` rule in `delivery.smk` to use the new Conda environment, enabling reproducible runs of the QC report script.

**Version update:**

* Bumped the project version in `pyproject.toml` from `1.9.0-rc2` to `1.9.0-rc3`.