### PR TITLE
Issue411

### DIFF
--- a/src/cgr_gwas_qc/cli/submit.py
+++ b/src/cgr_gwas_qc/cli/submit.py
@@ -83,6 +83,10 @@ def main(
         None,
         help="The maximum number of threads a rule can request. If pipeline is executed in `cluster_mode`, this will scale down the threads to `cores`.",
     ),
+    use_mamba: bool = typer.Option(
+        False,
+        help="Whether to use mamba as the conda frontend. Passed to snakemake with `--conda-frontend mamba` if True.",
+    ),
 ):
     """Submit the CGR GwasQcPipeline to a cluster for execution.
 
@@ -140,7 +144,10 @@ def main(
     }
     snake_config = {"cluster_mode": True, "notemp": False}
 
-    payload["added_options"] += "--conda-frontend conda "  # type: ignore
+    if use_mamba:
+        payload["added_options"] += "--conda-frontend mamba "  # type: ignore
+    else:
+        payload["added_options"] += "--conda-frontend conda "  # type: ignore
 
     if notemp:
         payload["added_options"] += "--notemp "  # type: ignore

--- a/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
+++ b/src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk
@@ -6,7 +6,9 @@ cfg = load_config()
 max_time = cfg.config.workflow_params.max_time_hr
 BIG_TIME = dict.fromkeys(range(1, 4), max_time) if max_time else {1: 10, 2: 48, 3: 96}
 
-use_contamination = cfg.config.user_files.idat_pattern and cfg.config.workflow_params.remove_contam
+use_contamination = (
+    cfg.config.user_files.idat_pattern or cfg.config.workflow_params.convert_gtc2bcf
+) and cfg.config.workflow_params.remove_contam
 
 idat_intensity_retrieved = Path("sample_level/contamination/median_idat_intensity.csv").is_file()
 


### PR DESCRIPTION
This pull request introduces a new option to select the conda frontend for Snakemake execution and updates the logic for contamination removal in the sample QC workflow. The most notable changes are the addition of the `use_mamba` option in the CLI and a refinement in the conditions for enabling contamination removal.

**CLI improvements:**

* Added a `use_mamba` boolean option to the `main` function in `src/cgr_gwas_qc/cli/submit.py`, allowing users to specify whether to use `mamba` as the conda frontend. If enabled, the appropriate flag is passed to Snakemake.
* Updated logic to append `--conda-frontend mamba` or `--conda-frontend conda` to the Snakemake command based on the `use_mamba` option.

**Sample QC workflow logic:**

* Modified the `use_contamination` condition in `src/cgr_gwas_qc/workflow/sub_workflows/sample_qc.smk` to enable contamination removal if either `idat_pattern` is set or `convert_gtc2bcf` is enabled, and `remove_contam` is true.